### PR TITLE
Hotfix to support pokemon token generation with the full range of transparent image formats

### DIFF
--- a/module/ptu.js
+++ b/module/ptu.js
@@ -61,7 +61,7 @@ export let log = (...args) => console.log("FVTT PTU | ", ...args);
 export let warn = (...args) => console.warn("FVTT PTU | ", ...args);
 export let error = (...args) => console.error("FVTT PTU | ", ...args)
 
-export const LATEST_VERSION = "2.0-Beta-4";
+export const LATEST_VERSION = "2.0-Beta-5";
 
 /* -------------------------------------------- */
 /*  Foundry VTT Initialization                  */

--- a/module/utils/species-command-parser.js
+++ b/module/utils/species-command-parser.js
@@ -80,6 +80,8 @@ export async function CreateMonParser(input, andCreate = false) {
 }
 
 export async function GetSpeciesArt(mon, imgDirectoryPath, type = ".webp", shiny = false, animated = false, animated_type = ".webm") {
+
+    const alt_type = ".png";
     const basePath = imgDirectoryPath+(imgDirectoryPath.endsWith('/') ? '' : '/')
 
     const shiny_path = shiny ? "s" : "";
@@ -100,6 +102,10 @@ export async function GetSpeciesArt(mon, imgDirectoryPath, type = ".webp", shiny
         path = basePath+lpad(mon?.number, 3)+shiny_path+type;
         result = await fetch(path);
     }
+    if(result.status === 404 && mon?.number < 1000) {
+        path = basePath+lpad(mon?.number, 3)+shiny_path+alt_type;
+        result = await fetch(path);
+    }
 
     if(animated && (result.status === 404)) {
         path = basePath+lpad(mon?.number, 4)+shiny_path+animated_type;
@@ -107,6 +113,10 @@ export async function GetSpeciesArt(mon, imgDirectoryPath, type = ".webp", shiny
     }
     if(result.status === 404) {
         path = basePath+lpad(mon?.number, 4)+shiny_path+type;
+        result = await fetch(path);
+    }
+    if(result.status === 404) {
+        path = basePath+lpad(mon?.number, 4)+shiny_path+alt_type;
         result = await fetch(path);
     }
 
@@ -118,6 +128,10 @@ export async function GetSpeciesArt(mon, imgDirectoryPath, type = ".webp", shiny
         path = basePath+mon?._id+shiny_path+type;
         result = await fetch(path);
     }
+    if(result.status === 404) {
+        path = basePath+mon?._id+shiny_path+alt_type;
+        result = await fetch(path);
+    }
 
     if(animated && (result.status === 404)) {
         path = basePath+mon?._id?.toLowerCase()+shiny_path+animated_type;
@@ -125,6 +139,10 @@ export async function GetSpeciesArt(mon, imgDirectoryPath, type = ".webp", shiny
     }
     if(result.status === 404) {
         path = basePath+mon?._id?.toLowerCase()+shiny_path+type;
+        result = await fetch(path);
+    }
+    if(result.status === 404) {
+        path = basePath+mon?._id?.toLowerCase()+shiny_path+alt_type;
         result = await fetch(path);
     }
 

--- a/system.json
+++ b/system.json
@@ -4,7 +4,7 @@
   "description": "A Pen and Paper Roleplaying Game Set in the World of Pokemon",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
-  "version": "2.0-Beta-4",
+  "version": "2.0-Beta-5",
 
   "templateVersion": 2,
   "author": "Dylan Piera, Tymo Wessel, Jeffrey Hollander, Efren A. Mariño & Cody Swendrowski",


### PR DESCRIPTION
Hotfix to support pokemon token generation with the full range of transparent image formats; in order, it will try .webm, .webp, and .png, stopping and using the first one it actually finds a corresponding image for.