### PR TITLE
BUGFIX `Filter` and `Solid Rock` Abilities

### DIFF
--- a/module/actor/calculations/effectiveness-calculator.js
+++ b/module/actor/calculations/effectiveness-calculator.js
@@ -83,6 +83,11 @@ export function GetMonEffectiveness(data) {
         }
     }
 
+    // When both Solid Rock and Filter are active, Super Effective multiplications should only be changed
+    // once, not twice. If both Abilites are there, only calculate one and leave the conditional Damage
+    // reduction to the player
+    if(abilities["Solid Rock"].active && abilities["Filter"].active) abilities["Filter"].active = false
+
     for(const [key,value] of Object.entries(abilities).filter(x => x[1].active == true)) {
         typeCalc = value.execute(typeCalc);
     }


### PR DESCRIPTION
Fixed a bug where if both abilities were on a Pokémon they would both calculate, resulting in 2x => 1.25x and 1.5x => 1.5x, instead of only one calculating and the other being left for (manual) Damage Reduction against Super-Effective Moves.


See https://github.com/dylanpiera/Foundry-Pokemon-Tabletop-United-System/issues/193