### PR TITLE
FEATURE Generated Pokemon Token can use Wildcards

### DIFF
--- a/module/forms/dex-drag-options-form.js
+++ b/module/forms/dex-drag-options-form.js
@@ -13,7 +13,7 @@ export class PTUDexDragOptions extends FormApplication {
         classes: ["ptu", "charactermancer", "pokemon", "dex_drag_in"],
         template: "systems/ptu/templates/forms/dex-drag-options-form.hbs",
         width: 250,
-        height: 375,
+        height: 430,
         title: "Dex Drag-In",
         tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "stats" }]
       });
@@ -31,6 +31,7 @@ export class PTUDexDragOptions extends FormApplication {
       data.shinyChanceDefault = game.settings.get("ptu", "defaultDexDragInShinyChance");
       data.statRandomnessDefault = game.settings.get("ptu", "defaultDexDragInStatRandomness");
       data.preventDefault = game.settings.get("ptu", "defaultDexDragInPreventEvolution");
+      data.wildcardToken = game.settings.get("ptu", "defaultDexDragInWildcardToken");
       data.species = this.object.item.name;
 
       return data;

--- a/module/settings.js
+++ b/module/settings.js
@@ -270,6 +270,16 @@ export function LoadSystemSettings() {
         category: "generation"
     });
 
+    game.settings.register("ptu", "defaultDexDragInWildcardToken", {
+        name: "Default Dex Drag-In Token With Wildcards",
+        hint: "Default setting for wildcarding Tokens of generated Pokemon by dragging them from the Dex. When 'wildcarded' and a picture such as my/path/001.png is found, the wildcard token will be my/path/001*.png (or any other suitable file extension as without wildcarding). Probably best experienced with 'Token HUD Wildcard'.",
+        scope: "world",
+        config: true,
+        type: Boolean,
+        default: false,
+        category: "generation"
+    });
+
     game.settings.register("ptu", "customSpecies", {
         name: "Custom Species json (Requires Refresh)",
         hint: "Please specify the path of a custom species file (inside the world directory) if you wish to add Homebrew Pokémon. [Currently in Beta!]",

--- a/module/utils/species-command-parser.js
+++ b/module/utils/species-command-parser.js
@@ -229,6 +229,7 @@ export async function FinishDexDragPokemonCreation(formData, update)
     let shiny_chance = parseInt(formData["data.shiny_chance"]);
     let stat_randomness = parseInt(formData["data.stat_randomness"]);
     let prevent_evolution = Number(formData["data.prevent_evolution"]);
+    let wildcard_token = Boolean(formData["data.wildcard_token"])
 
     let new_actor = await game.ptu.monGenerator.ActorGenerator.Create({
         exists: false,
@@ -260,7 +261,15 @@ export async function FinishDexDragPokemonCreation(formData, update)
     protoToken.bar1.attribute = "health";
 
     protoToken.img = await GetSpeciesArt(game.ptu.GetSpeciesData(new_actor.data.data.species), imgSrc, ".webp", new_actor.data.data.shiny, true);
-    
+
+    if(protoToken.img && wildcard_token){
+        protoToken.randomImg = true
+        protoToken.flags = {"token-hud-wildcard": {"default": protoToken.img}}
+        // To still allow dots being used anywhere in the path, we substitute the last . with *., but in reverse, so .*
+        protoToken.img = [...[...protoToken.img].reverse().join("").replace(".", ".*")].reverse().join("")
+
+    }
+
     new_actor = await new_actor.update({"token": protoToken});
 
     protoToken.x = Math.floor(drop_coordinates_x / game.scenes.viewed.data.grid) * game.scenes.viewed.data.grid;

--- a/templates/forms/dex-drag-options-form.hbs
+++ b/templates/forms/dex-drag-options-form.hbs
@@ -34,6 +34,10 @@
       <div><br>Prevent Evolution?</div><input type="checkbox" style="width: 20px; height: 20px;" id="prevent_evolution" name="data.prevent_evolution" {{checked preventDefault}}/>
     </div>
 
+    <div class="w-100 justify-content-center mb-2">
+      <div><br>Wildcard Token?</div><input type="checkbox" style="width: 20px; height: 20px;" id="wildcard_token" name="data.wildcard_token" {{checked wildcardToken}}/>
+    </div>
+
   </div>
 
   <div class="w-100 justify-content-center mt-auto">


### PR DESCRIPTION
Dex Drag-In Options Form has new Checkbox to decide whether to make make the PrototypeTokens Img wildcarded
Added new boolean setting ptu.generation.defaultDexDragInWildcardToken to toggle Default setting
The wildcard setting is honored iff a picture is found with the non wildcarded logic. In the case, the default image would be my/path/001.png and the wildcard is my/path/001*.png (or what ever file extension is found by the non-wildcarded behaviour)

See #179 

![image](https://user-images.githubusercontent.com/101654076/172736053-8cf04fe8-7588-4d9e-9e82-0b70d0192524.png)
![image](https://user-images.githubusercontent.com/101654076/172736082-2fdddd1c-3f82-4492-8017-97c52208955b.png)
![image](https://user-images.githubusercontent.com/101654076/172736378-56765a57-ded1-4b2c-a999-0083ebff401c.png)
