### PR TITLE
BUGFIX Pin Missle now Performs with Move Sounds activated

### DIFF
--- a/module/combat/effects/move_sounds.js
+++ b/module/combat/effects/move_sounds.js
@@ -36,9 +36,9 @@ Hooks.on("renderChatMessage", (message) => {
 });
 
 
-async function GetMoveSoundPath(move_name) 
+async function GetMoveSoundPath(moveData)
 {
-    let move_sound_path = "sounds/dice.wav";
+	const move_name = moveData.name
 
     let base_sound_directory = game.settings.get("ptu", "moveSoundDirectory");
     let move_name_path = ((move_name).replace(/( \[.*?\]| \(.*?\)) */g, "") + ".mp3"); // Remove things like [OG] or [Playtest] from move names when looking for sound files.
@@ -48,19 +48,15 @@ async function GetMoveSoundPath(move_name)
 		move_name_path = ("Hidden Power" + ".mp3");
 	}
 
-	if(move_name.toString().match(/Pin Missile/) != null)
+	if(moveData.fiveStrike && moveData.fiveStrike.is)
 	{
-		if((fiveStrikeCount+1) <= 1)
-		{
-			move_name_path = ("Pin Missile 1hit" + ".mp3");
-		}
-		else if((fiveStrikeCount+1) > 1)
-		{
-			move_name_path = ("Pin Missile 2hits" + ".mp3");
-		}
+		let count = moveData.fiveStrike.amount ?? 1
+		// Make it somewhere between 1 and 5, just in case
+		count = Math.min(5,Math.max(1, count))
+		move_name_path = `${move_name} ${count}hit.mp3`
 	}
 
-    move_sound_path = base_sound_directory + move_name_path;
+    let move_sound_path = base_sound_directory + move_name_path;
 
     return move_sound_path;
 }
@@ -116,7 +112,7 @@ export async function PlayMoveSounds(move, attacksData)
         return false; // Config settings have disabled move sounds, so stop here.
     }
 
-    let move_sound_path = await GetMoveSoundPath(move.name);
+    let move_sound_path = await GetMoveSoundPath(move);
 
     await AudioHelper.play({src: move_sound_path, volume: 0.8, autoplay: true, loop: false}, true);
 

--- a/module/combat/effects/move_sounds.js
+++ b/module/combat/effects/move_sounds.js
@@ -50,9 +50,8 @@ async function GetMoveSoundPath(moveData)
 
 	if(moveData.fiveStrike && moveData.fiveStrike.is)
 	{
-		let count = moveData.fiveStrike.amount ?? 1
 		// Make it somewhere between 1 and 5, just in case
-		count = Math.min(5,Math.max(1, count))
+		const count = Math.min(5,Math.max(1, moveData.fiveStrike.amount ?? 1))
 		move_name_path = `${move_name} ${count}hit.mp3`
 	}
 


### PR DESCRIPTION
FEATURE module/combat/effects/move_sounds.js:GetMoveSoundPath now uses the whole moveData instead of just the name, allowing to check for whether single or multiple hits of Five Strike Moves. Now not only Pin Missile but any Five Strike Move checks for amount if hits and looks for "{movename} 1hit.mp3" or "{movename} 2hit.mp3", as per previous naming scheme.

See #187