### PR TITLE
<feature> Pokedex button

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -191,9 +191,8 @@
     "PTU.Dreams": "Dreams",
     "PTU.Obsessions": "Obsessions",
 
-    "dexButton.ButtonName": "Pokédex",
-    "dexButton.ButtonHint": "Scan the pokemon with your pokédex",
-    "dexButton.ButtonFAIcon": "fas fa-tablet-alt",
+    "PTU.DexButtonName": "Pokédex",
+    "PTU.DexButtonHint": "Scan the pokemon with your pokédex",
 
     "SETTINGS.ptu": ""
 }

--- a/module/ptu.js
+++ b/module/ptu.js
@@ -862,32 +862,15 @@ Hooks.on("preCreateItem", async function (item, data, options, sender) {
   await item.data.update({ "data.origin": origin });
 });
 
-class dexButton extends Application {
-  constructor() {
-      super();
-  }
-}
-
 Hooks.on('getSceneControlButtons', function(hudButtons) {
-  let hud = hudButtons.find(val => { return val.name == "token"; })
+  const hud = hudButtons.find(val => val.name == "token")
   if (hud) {
       hud.tools.push({
-          name: "dexButton.ButtonName",
-          title: "dexButton.ButtonHint",
-          icon: game.i18n.localize("dexButton.ButtonFAIcon"),
+          name: "PTU.DexButtonName",
+          title: "PTU.DexButtonHint",
+          icon: "fas fa-tablet-alt",
           button: true,
-          onClick: async () => {
-              let db = new dexButton();
-              db.render(true);
-              game.ptu.pokedexMacro();
-          }
+          onClick: () => game.ptu.pokedexMacro()
       });
   }
 });
-
-Hooks.once('ready', async function() {
-  game.socket.on("system.ptu", data => {
-      let db = new dexButton();
-      db.render(true);
-  })
-})


### PR DESCRIPTION
added a pokédex button to the scene controls, under token controls

![image](https://user-images.githubusercontent.com/43385250/174840894-1a687b40-dc41-49b5-acc0-a3fa69c8fadc.png)

this would replace the need to drag the pokédex item onto the macro bar, and functions exactly the same as this macro.

![image](https://user-images.githubusercontent.com/43385250/174841120-a0e48a7f-52ee-41f0-a702-0439a6e76554.png)