### PR TITLE
Issue #183 - Double-Strike

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -942,8 +942,8 @@ export class PTUActor extends Actor {
         critType = (moveData.doubleStrike.hit1.crit == CritOptions.CRIT_HIT) && (moveData.doubleStrike.hit2.crit == CritOptions.CRIT_HIT) ? CritOptions.DOUBLE_CRIT_HIT : CritOptions.CRIT_HIT;
       }
       hitCount = 0;
-      if (moveData.doubleStrike.hit1.hit === true) hitCount++;
-      if (moveData.doubleStrike.hit2.hit === true) hitCount++;
+      if (!targetData || moveData.doubleStrike.hit1.hit === true) hitCount++;
+      if (!targetData || moveData.doubleStrike.hit2.hit === true) hitCount++;
     }
 
     if (moveData.fiveStrike.is === true) {


### PR DESCRIPTION
Might be a bit of a janky change, but seems to work to solve #183. Here are the in-game results.


Ambipom hits Blastoise twice with double hit

![image](https://user-images.githubusercontent.com/43385250/178242894-8d6e2e47-6cf0-4622-8019-ad2d45c97d08.png)

3 Dice rolled.



Ambipom only hits once with double hit

![image](https://user-images.githubusercontent.com/43385250/178243103-f109df12-fe7a-4a5d-84d9-a9aa555bc876.png)

2 dice tolled



No target selected

![image](https://user-images.githubusercontent.com/43385250/178243579-212bacc0-b6a7-47cd-8990-45faa910155e.png)

3 Dice rolled
