### PR TITLE
216 custom type images

### DIFF
--- a/module/ptu.js
+++ b/module/ptu.js
@@ -313,19 +313,29 @@ function registerHandlebars() {
   });
 
   Handlebars.registerHelper("loadTypeImages", function (types, includeSlash = true) {
+    // TypeEffectiveness here is imported from source and only contains the default types
+    // in contract, game.ptu.TypeEffectiveness contains custom types as well
+    const isTypeDefaultType = (typeName) => Object.keys(TypeEffectiveness).includes(typeName)
+    let customDir = game.settings.get("ptu", "typeEffectivenessCustomImageDirectory");
+    if (customDir.slice(-1) !== "/") customDir += "/"
+    if (customDir.charAt(0) !== "/") customDir = "/" + customDir
     if (!types) return;
     return types.reduce((html, type, index, array) => {
       if (type == "null") type = "Untyped";
-      return html += `<img class="mr-1 ml-1" src="/systems/ptu/css/images/types/${type}IC.webp">` + (includeSlash ? (index != (array.length - 1) ? "<span>/</span>" : "") : "");
+      if (isTypeDefaultType(type)) return html += `<img class="mr-1 ml-1" src="/systems/ptu/css/images/types/${type}IC.webp">` + (includeSlash ? (index != (array.length - 1) ? "<span>/</span>" : "") : "");
+      else return html += `<img class="mr-1 ml-1" src="${customDir}${type}IC.webp">` + (includeSlash ? (index != (array.length - 1) ? "<span>/</span>" : "") : "");
     }, "")
-
-    if (!types) return;
-    if (types[1] != "null") return `<img class="mr-1" src="/systems/ptu/css/images/types/${types[0]}IC.webp"><span>/</span><img class="ml-1" src="/systems/ptu/css/images/types/${types[1]}IC.webp">`;
-    return `<img src="/systems/ptu/css/images/types/${types[0]}IC.webp">`;
   });
 
   Handlebars.registerHelper("loadTypeImage", function (type) {
-    return `<img src="/systems/ptu/css/images/types/${type}IC.webp">`;
+    // TypeEffectiveness here is imported from source and only contains the default types
+    // in contract, game.ptu.TypeEffectiveness contains custom types as well
+    const isTypeDefaultType = (typeName) => Object.keys(TypeEffectiveness).includes(typeName)
+    let customDir = game.settings.get("ptu", "typeEffectivenessCustomImageDirectory");
+    if (customDir.slice(-1) !== "/") customDir += "/"
+    if (customDir.charAt(0) !== "/") customDir = "/" + customDir
+    if (isTypeDefaultType(type)) return `<img src="/systems/ptu/css/images/types/${type}IC.webp">`;
+    else return `<img src="${customDir}${type}IC.webp">`
   });
 
   Handlebars.registerHelper("isGm", function () {

--- a/module/settings.js
+++ b/module/settings.js
@@ -323,6 +323,17 @@ export function LoadSystemSettings() {
         default: undefined
     })
 
+    game.settings.register("ptu", "typeEffectivenessCustomImageDirectory", {
+        name: "Custom Type Image Directory",
+        hint: "Directory from which Images for Custom Types are attempted to load. Looks for [CaseSensitiveTypeName]IC.webp.",
+        scope: "world",
+        config: true,
+        type: String,
+        default: "custom_types/",
+        filePicker: true,
+        category: "other"
+    })
+
     game.settings.register("ptu", "showDebugInfo", {
         name: "Show Debug Info",
         hint: "Only for debug purposes. Logs extra debug messages & shows hidden folders/items",


### PR DESCRIPTION
As per #216 
new setting that allows to set a directory for custom Type Images. They **_MUST_** be named `/path/to/[caseSensitiveTypeName]IC.webp`.