### PR TITLE
Show roll for nomiss moves

### DIFF
--- a/templates/chat/moves/full-attack.hbs
+++ b/templates/chat/moves/full-attack.hbs
@@ -39,7 +39,6 @@
         </div>
         {{/if}}
         
-        {{#if hasAC}}
         <div class="swsh-header" style="padding: 0px ! important;background-color: #b3b3b3;">
             <div class="d-flex w-100 mt-0 mb-0" style="padding: 0px ! important;">
                 <div class="col" style="padding: 0px ! important; background-color:#272727 ! important;">
@@ -49,12 +48,11 @@
                 </div>
             </div>
         </div>
-        {{/if}}
 
-        <div class="swsh-body" style="background-color: #b3b3b3; ">
-            {{#if hasAC}}
-                <div class="dice-roll w-100" style="padding: 0px 0px; font-size: 10px ! important;">
-                    <div class="dice-result" style="padding: 0px 0px; font-size: 10px ! important;">
+        <div class="swsh-body" style="background-color: #b3b3b3; ">  
+            <div class="dice-roll w-100" style="padding: 0px 0px; font-size: 10px ! important;">
+                <div class="dice-result" style="padding: 0px 0px; font-size: 10px ! important;">
+                    {{#if hasAC}}
                         <div class="dice-formula" style="padding: 0px 0px; margin: 0px; font-size: 10px ! important;">  
                             {{#each acRoll.terms as | term |}}
                                 {{#if term.faces}}
@@ -176,9 +174,17 @@
                                 </span>
                             {{/if}}
                         {{/if}}
-                    </div>
+                    {{else}}
+                        <div class="dice-formula" style="padding: 0px 0px; margin: 0px; font-size: 10px ! important;">
+                            <span
+                                class="roll die d{{acRoll.terms.0.faces}} {{minMaxDiceCheck acRoll.terms.0.results.0.result acRoll.terms.0.faces}}"
+                                style="padding: 0px; margin: 0px; font-size: 8px ! important;">
+                                    {{acRoll.terms.0.results.0.result}}
+                            </span>
+                        </div>
+                    {{/if}}
                 </div>
-            {{/if}}
+            </div>           
 
             {{#unless noRoll}}
                 {{#if crit}}


### PR DESCRIPTION
Right now, the actual roll for nomiss moves is not displayed. This means the player has to rely on automation to know if they crit. This changes it so the d20 roll will be displayed by itself, making things clearer.
![image](https://user-images.githubusercontent.com/22105962/179635697-b5df856a-42cd-41cb-82ce-7d3d0281a388.png)
