### PR TITLE
BUGFIX: Pokedex Entry show correctly

### DIFF
--- a/templates/pokedex.hbs
+++ b/templates/pokedex.hbs
@@ -363,15 +363,13 @@
         {{/if}}
     </div>
 
-    {{#if dexEntry}}
-        {{#if dexEntry.data.entry}}
-            <div class='row readable pt-2'>
-                <div class='col' style='text-align: left;'>
-                    <h3><strong>Dex Entry</strong></h3>
-                
-                    {{{dexEntry.data.entry}}}
-                </div>
+    {{#if dexEntry.system.entry}}
+        <div class='row readable pt-2'>
+            <div class='col' style='text-align: left;'>
+                <h3><strong>Dex Entry</strong></h3>
+            
+                {{{dexEntry.system.entry}}}
             </div>
-        {{/if}}
+        </div>
     {{/if}}
 </div>

--- a/templates/pokedex.hbs
+++ b/templates/pokedex.hbs
@@ -363,13 +363,15 @@
         {{/if}}
     </div>
 
-    {{#if dexEntry.system.entry}}
-        <div class='row readable pt-2'>
-            <div class='col' style='text-align: left;'>
-                <h3><strong>Dex Entry</strong></h3>
-            
-                {{{dexEntry.system.entry}}}
+    {{#if dexEntry}}
+        {{#if dexEntry.system.entry}}
+            <div class='row readable pt-2'>
+                <div class='col' style='text-align: left;'>
+                    <h3><strong>Dex Entry</strong></h3>
+                
+                    {{{dexEntry.system.entry}}}
+                </div>
             </div>
-        </div>
+        {{/if}}
     {{/if}}
 </div>


### PR DESCRIPTION
fixed an issue where the dex entry description was not showing for pokemon when scanned with the pokedex

![image](https://user-images.githubusercontent.com/43385250/210255605-d79a05e8-8cb1-4a56-95bd-b582983e4f66.png)

![image](https://user-images.githubusercontent.com/43385250/210255531-53f34e0f-878e-43f8-9f70-a6742e0c308a.png)

<details>
<summary>How it appeared before changes</summary>

![image](https://user-images.githubusercontent.com/43385250/210256035-b85f71b0-5aa8-450e-aa48-f742b6694b59.png)

![image](https://user-images.githubusercontent.com/43385250/210255970-ad627724-5fcf-4a43-a983-16f5e61f462c.png)

</details>