### PR TITLE
Learn Moves Dialog

### DIFF
--- a/module/settings.js
+++ b/module/settings.js
@@ -767,6 +767,16 @@ export function LoadSystemSettings() {
             default: true,
             category: "combat"
         })
+
+        game.settings.register("ptu", "pokemonLearnMovesMessage", {
+            name: "GM Setting: Show message when a pokemon learns a new move from leveling up.",
+            hint: "This will show a pop up for players when there pokemon learns new moves from gaining experience. They can then add those moves to their move list.",
+            scope: "world",
+            config: true,
+            type: Boolean,
+            default: true,
+            category: "other"
+        })
     }
 }
 

--- a/module/utils/generic-helpers.js
+++ b/module/utils/generic-helpers.js
@@ -1,8 +1,9 @@
 /* -- Helper Functions -- */
 
-// import { pokemonData } from "../data/species-data";
-// import { levelProgression } from "../data/level-progression";
-// import { CalcLevel } from "../actor/calculations/level-up-calculator";
+import { pokemonData } from "../data/species-data.js";
+import { levelProgression } from "../data/level-progression.js";
+import { CalcLevel } from "../actor/calculations/level-up-calculator.js";
+import { GetOrCacheMoves } from "./cache-helper.js";
 
 export function getRandomIntInclusive(min, max) {
     min = Math.ceil(min);
@@ -52,6 +53,10 @@ export function capitalizeFirstLetter(string) {
 }
 
 Hooks.on("preUpdateActor", async (oldActor, changes, options, sender) => {
+    //check if this is turned off in settings
+    const setting = game.settings.get("ptu", "pokemonLearnMovesMessage")
+    if(!setting) return; // option turned off by GM
+
     if(changes.system?.level?.exp === undefined) return;
 
     const oldLvl = CalcLevel(oldActor.system.level.exp, 50, levelProgression);
@@ -61,19 +66,65 @@ Hooks.on("preUpdateActor", async (oldActor, changes, options, sender) => {
     if(newLvl > oldLvl) {
         //mons dex entry
         const dexEntry = pokemonData.find(e => e._id.toLowerCase() === oldActor.system.species.toLowerCase() )
-        let lvl = oldLvl + 1;
-        let newMoves = [];
-        while(lvl <= newLvl)
-        { 
-            //check if the mon learns new moves
-            const move = dexEntry.get("Level Up Move List").find(m => m.level === lvl)
-            if(move) newMoves.push(move);
-            //increment lvl
-            lvl++;
-        }
+       
+        const newMoveNames=[dexEntry["Level Up Move List"]][0].filter(m => m.Level > oldLvl && m.Level <= newLvl).map(m => m.Move);
+        const allMoves =  await GetOrCacheMoves()
+        const newMoves = [...allMoves].filter(m => newMoveNames.includes(m.name));
 
         if(newMoves.length > 0) {
-            //send new moves to chat/popup
+            //show dialog
+            let d = new Dialog({
+                title: `${oldActor.name} is trying to learn new moves!`,
+                content: "Please click buttons to add the moves to your pokemon's move list.<br> You can remove them later if you want.<br><br><br>",
+                buttons: {},
+                default: "done"                          
+            });
+
+            d.position.width = 600;
+            d.options.resizable = true;
+
+            newMoves.forEach((move, i) => {
+                d.data.buttons[`move${i}`] = {
+                    label: `${move.name}`,
+                    classes: ["learn-moves"],
+                    callback: async () => {                                                           
+                        d.render(true);//don't close the dialog
+                        //check if old actor already has the move
+                        if(oldActor.moves.find(m => m.name.toLowerCase() === move.name.toLowerCase())) {
+                            ui.notifications.info(`${oldActor.name} already knows ${move.name}!}`);
+                        } else {
+                            //add the move to the actors list of moves
+                            await oldActor.createEmbeddedDocuments("Item", [move]);
+                        }                                
+                    }
+                };
+            });
+
+            d.data.buttons["done"] = {
+                label: "Done",
+                classes: ["learn-moves"],
+                callback: () => {
+                    d.close();
+                    const closed = new Dialog({
+                        title: oldActor.name,
+                        content: `${oldActor.name} now knows ${oldActor.moves.length} moves! Please remove some if needed.<br><br><br>`,
+                        buttons: {
+                            ["ok"]: {
+                                label: "OK",
+                                callback: () => {
+                                    closed.close();
+                                }
+                            }
+                        }
+                    })
+
+                    if(oldActor.moves.length > 6) 
+                        closed.render(true);
+                }
+            }
+
+            d.render(true);
+            
         }
     }
 });

--- a/module/utils/generic-helpers.js
+++ b/module/utils/generic-helpers.js
@@ -1,5 +1,9 @@
 /* -- Helper Functions -- */
 
+// import { pokemonData } from "../data/species-data";
+// import { levelProgression } from "../data/level-progression";
+// import { CalcLevel } from "../actor/calculations/level-up-calculator";
+
 export function getRandomIntInclusive(min, max) {
     min = Math.ceil(min);
     max = Math.floor(max);
@@ -46,3 +50,30 @@ export function timeout(ms) {
 export function capitalizeFirstLetter(string) {
     return string[0].toUpperCase() + string.slice(1);
 }
+
+Hooks.on("preUpdateActor", async (oldActor, changes, options, sender) => {
+    if(changes.system?.level?.exp === undefined) return;
+
+    const oldLvl = CalcLevel(oldActor.system.level.exp, 50, levelProgression);
+    const newLvl = CalcLevel(changes.system.level.exp, 50, levelProgression);
+    
+    
+    if(newLvl > oldLvl) {
+        //mons dex entry
+        const dexEntry = pokemonData.find(e => e._id.toLowerCase() === oldActor.system.species.toLowerCase() )
+        let lvl = oldLvl + 1;
+        let newMoves = [];
+        while(lvl <= newLvl)
+        { 
+            //check if the mon learns new moves
+            const move = dexEntry.get("Level Up Move List").find(m => m.level === lvl)
+            if(move) newMoves.push(move);
+            //increment lvl
+            lvl++;
+        }
+
+        if(newMoves.length > 0) {
+            //send new moves to chat/popup
+        }
+    }
+});

--- a/module/utils/generic-helpers.js
+++ b/module/utils/generic-helpers.js
@@ -91,7 +91,7 @@ Hooks.on("preUpdateActor", async (oldActor, changes, options, sender) => {
                         d.render(true);//don't close the dialog
                         //check if old actor already has the move
                         if(oldActor.moves.find(m => m.name.toLowerCase() === move.name.toLowerCase())) {
-                            ui.notifications.info(`${oldActor.name} already knows ${move.name}!}`);
+                            ui.notifications.info(`${oldActor.name} already knows ${move.name}!`);
                         } else {
                             //add the move to the actors list of moves
                             await oldActor.createEmbeddedDocuments("Item", [move]);


### PR DESCRIPTION
This adds a new Dialog when a pokemon would learn a new move from leveling up #281 

![image](https://user-images.githubusercontent.com/43385250/212055812-6f84a69c-e653-4455-a79c-9018f2d787be.png)

Users can click the buttons to add the moves to the pokemons moves list.

also works if the pokemon gains lots of exp at the same time as multiple moves can display

![image](https://user-images.githubusercontent.com/43385250/212056066-2c1e11b9-ac52-4ba7-92df-9aa62b82bf1e.png)

After adding the moves it then warns the player if the mon knows more than 6 moves that they will need to remove some.

![image](https://user-images.githubusercontent.com/43385250/212056176-6abe7cb9-c663-4a1c-9f45-fb09f609739a.png)

This pop-up can be disabled in the settings by the GM

![image](https://user-images.githubusercontent.com/43385250/212056278-a8973e10-07e6-4725-9d73-310783ff0208.png)
