### PR TITLE
fixing fillable entries in Extra and Moves tabs of Trainer Sheets + Item Piles Compatibility Update

### DIFF
--- a/module/utils/item-piles-compatibility-handler.js
+++ b/module/utils/item-piles-compatibility-handler.js
@@ -65,17 +65,28 @@ Hooks.on("item-piles-preDropItemDetermined", function(a, b, dropped_item, d) {
 
 
 Hooks.on("item-piles-createItemPile", async function(created_token, options) {
+
+    // check if the item pile being created is a pile or not (chest, vault, merchant are other possibilities)
+    let flags = created_token?.data?.actorData?.flags;
+    
     // Set the name of the item pile to be either the name of the item, or a fallback generic name,
     // set the image (have to do it here, not earlier, since we can't do async fetches for item images
     // in time until the token exists), and set a flag in case Token Tooltip Alt is being used that 
     // marks the item pile as a token that should not have the usual tooltips.
-    let pile_name = created_token?.data?.actorData?.items?.[0]?.name ?? "Pile of Items";
-    let new_image = await GetItemArt(pile_name);
+    //
+    // only activates if the pile is an item pile, and not if the pile is a chest, vault, or merchant
+    if(flags["item-piles"]?.data?.type == "pile") {
+        let pile_name = created_token?.data?.actorData?.items?.[0]?.name ?? "Pile of Items";
+        let new_image = await GetItemArt(pile_name);
+        await created_token.update({
+            "name": pile_name, 
+            "img": ( new_image )
+        });
+    }
     await created_token.update({
-        "name": pile_name, 
-        "flags.token-tooltip-alt.noTooltip":true,
-        "img": ( new_image )
+        "flags.token-tooltip-alt.noTooltip":true
     });
+    
     // await created_token.data.actorData.items[0].update({ // TODO: Figure out how to update the actual items within the unlinked actor that get created here, since they don't trip the createItem hook
     //     "img": ( new_image )
     // });

--- a/templates/actor/character-sheet-gen8.hbs
+++ b/templates/actor/character-sheet-gen8.hbs
@@ -281,7 +281,7 @@
                   <div class="col-sm-6 small-input">
                     {{> "systems/ptu/templates/partials/mod-field.hbs" 
                       mod=data.modifiers.damageBonus.physical.mod 
-                      path="data.modifiers.damageBonus.physical.value" 
+                      path="system.modifiers.damageBonus.physical.value" 
                       value=data.modifiers.damageBonus.physical.value 
                       total=data.modifiers.damageBonus.physical.total
                       dtype="Number"
@@ -291,7 +291,7 @@
                   <div class="col-sm-6 small-input">
                     {{> "systems/ptu/templates/partials/mod-field.hbs" 
                       mod=data.modifiers.damageBonus.special.mod 
-                      path="data.modifiers.damageBonus.special.value" 
+                      path="system.modifiers.damageBonus.special.value" 
                       value=data.modifiers.damageBonus.special.value 
                       total=data.modifiers.damageBonus.special.total
                       dtype="Number" 
@@ -788,8 +788,8 @@
                     <div class="d-flex w-100 mt-1 mb-1">
                       <div class="col-sm-6">
                         {{> "systems/ptu/templates/partials/mod-field.hbs" 
-                          mod=data.modifiers.initiative.mod 
-                          path="data.modifiers.initiative.value" 
+                          mod=system.modifiers.initiative.mod 
+                          path="system.modifiers.initiative.value" 
                           value=data.modifiers.initiative.value 
                           total=data.modifiers.initiative.total
                           dtype="Number"
@@ -799,7 +799,7 @@
                       <div class="col-sm-6">
                         {{> "systems/ptu/templates/partials/mod-field.hbs" 
                           mod=data.modifiers.statPoints.mod 
-                          path="data.modifiers.statPoints.value" 
+                          path="system.modifiers.statPoints.value" 
                           value=data.modifiers.statPoints.value 
                           total=data.modifiers.statPoints.total
                           dtype="Number" 
@@ -826,7 +826,7 @@
                       <div class="col-sm-4">
                         {{> "systems/ptu/templates/partials/mod-field.hbs" 
                           mod=data.modifiers.acBonus.mod 
-                          path="data.modifiers.acBonus.value" 
+                          path="system.modifiers.acBonus.value" 
                           value=data.modifiers.acBonus.value 
                           total=data.modifiers.acBonus.total
                           dtype="Number" 
@@ -836,7 +836,7 @@
                       <div class="col-sm-4">
                         {{> "systems/ptu/templates/partials/mod-field.hbs" 
                           mod=data.modifiers.critRange.mod 
-                          path="data.modifiers.critRange.value" 
+                          path="system.modifiers.critRange.value" 
                           value=data.modifiers.critRange.value 
                           total=data.modifiers.critRange.total
                           dtype="Number" 
@@ -846,7 +846,7 @@
                       <div class="col-sm-4">
                         {{> "systems/ptu/templates/partials/mod-field.hbs" 
                           mod=data.modifiers.effectRange.mod 
-                          path="data.modifiers.effectRange.value" 
+                          path="system.modifiers.effectRange.value" 
                           value=data.modifiers.effectRange.value 
                           total=data.modifiers.effectRange.total
                           dtype="Number" 
@@ -877,7 +877,7 @@
                       <div class="col-sm-6">
                         {{> "systems/ptu/templates/partials/mod-field.hbs" 
                           mod=data.modifiers.damageReduction.physical.mod 
-                          path="data.modifiers.damageReduction.physical.value" 
+                          path="system.modifiers.damageReduction.physical.value" 
                           value=data.modifiers.damageReduction.physical.value 
                           total=data.modifiers.damageReduction.physical.total
                           dtype="Number" 
@@ -886,7 +886,7 @@
                       <div class="col-sm-6">
                         {{> "systems/ptu/templates/partials/mod-field.hbs" 
                           mod=data.modifiers.damageReduction.special.mod 
-                          path="data.modifiers.damageReduction.special.value" 
+                          path="system.modifiers.damageReduction.special.value" 
                           value=data.modifiers.damageReduction.special.value 
                           total=data.modifiers.damageReduction.special.total
                           dtype="Number" 
@@ -912,7 +912,7 @@
                       <div class="col-sm-4">
                         {{> "systems/ptu/templates/partials/mod-field.hbs" 
                           mod=data.modifiers.evasion.physical.mod 
-                          path="data.modifiers.evasion.physical.value" 
+                          path="system.modifiers.evasion.physical.value" 
                           value=data.modifiers.evasion.physical.value 
                           total=data.modifiers.evasion.physical.total
                           dtype="Number" 
@@ -921,7 +921,7 @@
                       <div class="col-sm-4">
                         {{> "systems/ptu/templates/partials/mod-field.hbs" 
                           mod=data.modifiers.evasion.special.mod 
-                          path="data.modifiers.evasion.special.value" 
+                          path="system.modifiers.evasion.special.value" 
                           value=data.modifiers.evasion.special.value 
                           total=data.modifiers.evasion.special.total 
                           dtype="Number" 
@@ -930,7 +930,7 @@
                       <div class="col-sm-4">
                         {{> "systems/ptu/templates/partials/mod-field.hbs" 
                           mod=data.modifiers.evasion.speed.mod 
-                          path="data.modifiers.evasion.speed.value" 
+                          path="system.modifiers.evasion.speed.value" 
                           value=data.modifiers.evasion.speed.value 
                           total=data.modifiers.evasion.speed.total
                           dtype="Number" 


### PR DESCRIPTION
Fixing #315 (things missed in #308 fix). Specifically on the `Extra` and `Moves` tab of the Trainer Character Sheets. Fixes include:
- Physical/Special Damage Mod on `Moves` tab
- All the Modifiers in the `Extra` tab

**02/01/2023**
- Updated `item-piles-compatibility-handler.js` to only update the token art and name of an item pile if it is of the type `pile`. If it is a `merchant`, `vault`, or `container`, the token art and name will not be changed.