### PR TITLE
automate broken balls when mon escapes

### DIFF
--- a/module/combat/effects/pokeball_effects.js
+++ b/module/combat/effects/pokeball_effects.js
@@ -407,7 +407,7 @@ export async function ThrowPokeball(thrower, target, pokeball) {
             if (game.settings.get("ptu", "trackBrokenPokeballs"))
             {
                 //check if thrower already has a broken ball of that type
-                let brokenBall = thrower.items.find(i => i.name == "Broken " + pokeball.name);
+                const brokenBall = thrower.items.find(i => i.name == "Broken " + pokeball.name);
 
                 if (brokenBall) //if they do, increment the quantity
                     await brokenBall.update({"system.quantity": duplicate(brokenBall.system.quantity)+1})

--- a/module/combat/effects/pokeball_effects.js
+++ b/module/combat/effects/pokeball_effects.js
@@ -403,6 +403,26 @@ export async function ThrowPokeball(thrower, target, pokeball) {
                 // await target.TMFXdeleteFilters("pokeball_transform");
                 await game.ptu.utils.api.gm.removeTokenMagicFilters(target, game.canvas.scene.id, "pokeball_transform");
             }
+
+            if (game.settings.get("ptu", "trackBrokenPokeballs"))
+            {
+                //check if thrower already has a broken ball of that type
+                let brokenBall = thrower.items.find(i => i.name == "Broken " + pokeball.name);
+
+                if (brokenBall) //if they do, increment the quantity
+                    await brokenBall.update({"system.quantity": duplicate(brokenBall.system.quantity)+1})
+                else //if they don't, create a new item
+                {
+                    await thrower.createEmbeddedDocuments('Item',[{
+                        name: `Broken ${pokeball.name}`,
+                        type: "item",
+                        system: {
+                            quantity: 1
+                        },
+                        img: pokeball.img
+                    }])
+                }
+            }
         }
 
         return isCaptured;

--- a/module/settings.js
+++ b/module/settings.js
@@ -682,14 +682,15 @@ export function LoadSystemSettings() {
         //     });
 
 
-        //     game.settings.register("PTUMoveMaster", "trackBrokenPokeballs", {
-        //         name: "GM Setting: Track Broken Pokeballs.",
-        //         hint: "The trainer edge 'Poke Ball Repair' allows for re-using balls that break upon failing to capture a Pokemon, so Move Master will automatically created a broken version of balls in the thrower's inventory when a Pokemon breaks free. If you have no use for tracking this, you can disable it here.",
-        //         scope: "world",
-        //         config: true,
-        //         type: Boolean,
-        //         default: true
-        //     });
+        game.settings.register("ptu", "trackBrokenPokeballs", {
+            name: "GM Setting: Track Broken Pokeballs.",
+            hint: "The trainer edge 'Poke Ball Repair' allows for re-using balls that break upon failing to capture a Pokemon, so Move Master will automatically created a broken version of balls in the thrower's inventory when a Pokemon breaks free. If you have no use for tracking this, you can disable it here.",
+            scope: "world",
+            config: true,
+            type: Boolean,
+            default: true,
+            category: "combat"
+        });
 
         game.settings.register("ptu", "customItemIconDirectory", {
             name: "Custom Item Icons Directory",


### PR DESCRIPTION
Change so that when a pokémon escape the pokéball players will get a broken pokéball of the type used.

this can be turned off in the settings under Combat, by the GM.