### PR TITLE
Stats rework

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -2,7 +2,7 @@ import { CalcLevel } from "./calculations/level-up-calculator.js";
 import { CalculateEvasions } from "./calculations/evasion-calculator.js";
 import { CalculatePokemonCapabilities, CalculateTrainerCapabilities } from "./calculations/capability-calculator.js";
 import { CalculateSkills } from "./calculations/skills-calculator.js";
-import { CalcBaseStats, CalculateStatTotal, CalculatePoisonedCondition } from "./calculations/stats-calculator.js";
+import { CalcBaseStats, CalculateStatTotal, CalculatePTStatTotal, CalculatePoisonedCondition } from "./calculations/stats-calculator.js";
 import { GetMonEffectiveness } from "./calculations/effectiveness-calculator.js";
 import { CritOptions } from "./character-sheet-gen8.js";
 import { warn, debug, log } from '../ptu.js'
@@ -414,7 +414,9 @@ export class PTUActor extends Actor {
 
     data.levelUpPoints = data.level.current + data.modifiers.statPoints.total + 9;
     data.stats = CalculatePoisonedCondition(duplicate(data.stats), actorData.flags?.ptu);
-    var result = CalculateStatTotal(data.levelUpPoints, data.stats, { twistedPower: actorData.items.find(x => x.name.toLowerCase().replace("[playtest]") == "twisted power") != null });
+    var result = game.settings.get("ptu", "playtestStats") ?
+      CalculatePTStatTotal(data.levelUpPoints, data.level.current, data.stats, { twistedPower: actorData.items.find(x => x.name.toLowerCase().replace("[playtest]") == "twisted power") != null }, data.nature.value) :
+      CalculateStatTotal(data.levelUpPoints, data.stats, { twistedPower: actorData.items.find(x => x.name.toLowerCase().replace("[playtest]") == "twisted power") != null });
     data.stats = result.stats;
     data.levelUpPoints = result.levelUpPoints;
 
@@ -487,7 +489,9 @@ export class PTUActor extends Actor {
 
     data.stats = CalcBaseStats(data.stats, speciesData, data.nature.value);
 
-    var result = CalculateStatTotal(data.levelUpPoints, data.stats, { twistedPower: actorData.items.find(x => x.name.toLowerCase().replace("[playtest]") == "twisted power") != null });
+    var result = game.settings.get("ptu", "playtestStats") ?
+    CalculatePTStatTotal(data.levelUpPoints, data.level.current, data.stats, { twistedPower: actorData.items.find(x => x.name.toLowerCase().replace("[playtest]") == "twisted power") != null }, data.nature.value) :
+      CalculateStatTotal(data.levelUpPoints, data.stats, { twistedPower: actorData.items.find(x => x.name.toLowerCase().replace("[playtest]") == "twisted power") != null });
     data.stats = result.stats;
     data.levelUpPoints = result.levelUpPoints;
 

--- a/module/actor/calculations/stats-calculator.js
+++ b/module/actor/calculations/stats-calculator.js
@@ -1,5 +1,5 @@
 function CalcBaseStat(specie, nature, statKey) {
-    if (specie != null) return _calculateStatWithNature(nature, statKey, _fetchSpecieStat(specie, statKey));
+    if (specie != null) return game.settings.get("ptu", "playtestStats") ? _fetchSpecieStat(specie, statKey) : _calculateStatWithNature(nature, statKey, _fetchSpecieStat(specie, statKey));
     return 0;
 }
 
@@ -12,7 +12,7 @@ export function CalcBaseStats(stats, speciesData, nature, ignoreStages = false) 
     newStats.spatk.value = CalcBaseStat(speciesData, nature, "Special Attack", ignoreStages);
     newStats.spdef.value = CalcBaseStat(speciesData, nature, "Special Defense", ignoreStages);
     newStats.spd.value = CalcBaseStat(speciesData, nature, "Speed", ignoreStages);
-
+    
     return newStats;
 }
 
@@ -30,6 +30,7 @@ function _calculateStatWithNature(nature, statKey, stat) {
 }
 
 export function CalculateStatTotal(levelUpPoints, stats, {twistedPower, ignoreStages}) {
+
     for (const [key, value] of Object.entries(stats)) {
         const sub = value["value"] + value["mod"].value + value["mod"].mod + value["levelUp"];
         levelUpPoints -= value["levelUp"];
@@ -56,6 +57,83 @@ export function CalculateStatTotal(levelUpPoints, stats, {twistedPower, ignoreSt
             stats.atk.total += Math.floor(spatkTotal / 2);
             stats.spatk.total += Math.floor(atkTotal / 2);
         //}
+    }
+
+    return {
+        "levelUpPoints": levelUpPoints,
+        "stats": stats
+    };
+}
+
+// Calculate the sigma modifier - standard deviation of the array of stats
+function Dev(stats) {
+    const statsArray = Object.entries(stats);
+    const values = statsArray.map(item => item[1].total);
+  
+    const sum = values.reduce((total, value) => total + value, 0);
+    const mean = sum / values.length;
+  
+    const squaredDiffs = values.map(value => Math.pow(value - mean, 2));
+    const variance = squaredDiffs.reduce((total, value) => total + value, 0) / values.length;
+  
+    const standardDeviation = Math.sqrt(variance);
+  
+    return standardDeviation;
+  }
+
+export function CalculatePTStatTotal(levelUpPoints, level, stats, {twistedPower, ignoreStages}, nature) {
+
+    //find the gross stats = (Base Stat + (level * LevelUpPoints) * Level to the power of 1/2.2)/50 + Base Stat + LevelUpPOints/5
+    for (const [key, value] of Object.entries(stats)) {
+        value["total"] = (value["value"] + (level + value["levelUp"]) * Math.pow(level, 1/2.2))/50 + value["value"] + value["levelUp"]/5;
+        levelUpPoints -= value["levelUp"];       
+    }
+
+    //calculate sigma modifier = 1 + level/(100*sigma)
+    const sigma = 1 + level/(100*Dev(stats));
+
+    //apply sigma modifier
+    for (const [key, value] of Object.entries(stats)) {
+        value["total"] *= sigma;
+
+        //apply nature
+        if(nature != "" && game.ptu.data.natureData[nature] != null) {
+            if(game.ptu.data.natureData[nature][0] == key) {
+                value["total"] *= 1.1;
+            } else if(game.ptu.data.natureData[nature][1] == key) {
+                value["total"] = Math.max(value["total"] * 0.9, 1);
+            }
+        }
+
+        //round
+        value["total"] = Math.round(value["total"]);
+    }  
+
+    if(twistedPower) {
+        let atkTotal = stats.atk.total;
+        let spatkTotal = stats.spatk.total;
+        //if(Math.abs(atkTotal - spatkTotal) <= 5 ) {
+            stats.atk.total += Math.floor(spatkTotal / 2);
+            stats.spatk.total += Math.floor(atkTotal / 2);
+        //}
+    }
+
+    //apply mods and stages last
+    for (const [key, value] of Object.entries(stats)) {
+        const sub = value["total"] + value["mod"].value + value["mod"].mod;
+        if(ignoreStages) {
+            value["total"] = sub; continue;
+        }
+
+        if ((value["stage"]?.value + value["stage"]?.mod) > 0) {
+            value["total"] = Math.floor(sub * (value["stage"]?.value + value["stage"]?.mod) * 0.2 + sub);
+        } else {
+            if (key == "hp") {
+                value["total"] = sub;
+            } else {
+                value["total"] = Math.ceil(sub * (value["stage"]?.value + value["stage"]?.mod) * 0.1 + sub);
+            }
+        }
     }
 
     return {

--- a/module/settings.js
+++ b/module/settings.js
@@ -777,6 +777,16 @@ export function LoadSystemSettings() {
             default: true,
             category: "other"
         })
+
+        game.settings.register("ptu", "playtestStats", {
+            name: "PLAYTEST: Use playtest calculations for stats.",
+            hint: "This will use the playtest calculations for stats instead of the official ones. For further information see the discord.",
+            scope: "world",
+            config: true,
+            type: Boolean,
+            default: false,
+            category: "general"
+        })
     }
 }
 

--- a/module/settings.js
+++ b/module/settings.js
@@ -780,7 +780,7 @@ export function LoadSystemSettings() {
 
         game.settings.register("ptu", "playtestStats", {
             name: "PLAYTEST: Use playtest calculations for stats.",
-            hint: "This will use the playtest calculations for stats instead of the official ones. For further information see the discord.",
+            hint: "This will use the playtest calculations for stats instead of the official ones. For further information see the playtest.md file.",
             scope: "world",
             config: true,
             type: Boolean,

--- a/playtest.md
+++ b/playtest.md
@@ -60,8 +60,8 @@ This effect also scales with level, so will have a higher impact in later levels
 If we go back to the list of objectives that this change had:
 
 **Full Tank was Bad.**
--after doing some turns to kill calculations, using the same point distribution as in the above workbook we found that using this system Tanks take on average twice as long to be killed by the agressive glass cannons. They can actually tank now!
--in addition to this the wet noodle fight of 200+ turns now does not occur, as the attack stats of the tank naturally increase it means that on average fights between full tanks will take around 10 turns if no super effective moves are used. This is obviously not as fast as if two glass cannons were to fight but still much better.
+- after doing some turns to kill calculations, using the same point distribution as in the above workbook we found that using this system Tanks take on average twice as long to be killed by the agressive glass cannons. They can actually tank now!
+- in addition to this the wet noodle fight of 200+ turns now does not occur, as the attack stats of the tank naturally increase it means that on average fights between full tanks will take around 10 turns if no super effective moves are used. This is obviously not as fast as if two glass cannons were to fight but still much better.
 
 **Glass cannons too stronk**
 - Glass cannons have been nerfed as part of this system. with average turns to kill being increased by a range of 1.5-2 times!
@@ -69,11 +69,14 @@ If we go back to the list of objectives that this change had:
 - In a fight between two glass cannons, it is still possible for one of them to one-shot the other, but it is no longer a consistant thing, it will rely on super effective moves, crits and high damage rolls. So when it does happen it should hopefully be more of a "WOW!" moment.
 
 **Even builds get left behind**
+
 As demonstrated above we've added the Sigma modifier to make it so that Even builds can be more of the Jack of all Trades. They get an increase to their stats so that a generalised pokemons stat total will actually be higher than the stat total of a glass cannon or a tank. This makes this playstyle much more viable.
 
 **The Essence of Base Stat Relations**
--Because this system scales with Base Stats a naturally fast pokemon, will always be pretty fast, even with zero investment into the stat. This means that we can allow players to point level up points wherever they want without worrying about the essence of the pokemon being effected.
--For example, Pikachu's highest base stat is speed, and it's lowest is defense. If you put all your level up points into defense because you want a chonky season 1 pikachu, not the skinny rubbish they brought out in later seasons, defense doesn't actually become the highest stat until level 20!
+
+Because this system scales with Base Stats a naturally fast pokemon, will always be pretty fast, even with zero investment into the stat. This means that we can allow players to point level up points wherever they want without worrying about the essence of the pokemon being effected.
+
+For example, Pikachu's highest base stat is speed, and it's lowest is defense. If you put all your level up points into defense because you want a chonky season 1 pikachu, not the skinny rubbish they brought out in later seasons, defense doesn't actually become the highest stat until level 20!
 
 
 ### How can I take part?

--- a/playtest.md
+++ b/playtest.md
@@ -1,0 +1,10 @@
+# Welcome to the Playtest!
+
+
+### What is this playtest
+
+### Why
+
+### How it works
+
+### How can I take part?

--- a/playtest.md
+++ b/playtest.md
@@ -1,20 +1,20 @@
-# Welcome to the Playtest!
+# Welcome to the Stats Playtest!
 
 
-### What is this playtest?
-This playtest is being used to gather feedback for a potential new system of calculating a pokemons statistics, it takes inspiration from the Gen III games.
+## What is this playtest?
+This playtest is being used to gather feedback for a potential new system of calculating a pokemons statistics, it takes inspiration from the video game's in-game stat calculation used in the Gen III and later games.
 
-### Why?
-The current system of **Base Stat Relations** is flawed. Many people completely ignore it and it has many issues with balancing, especially when comparing full tanks, vs 'glass cannons'. You can find full details of these issues written in this google docs sheet: https://docs.google.com/document/d/1rOlOdksd0QNTiAO2vLU6uYes0aAxGzFe1n5wuDdGmVg/edit
+## Why?
+The current system of ***Base Stat Relations*** is flawed. Many people completely ignore it and it has many issues with balancing, especially when comparing full tanks, vs 'glass cannons'. You can find full details of these issues written in this google docs sheet: [Turns to Kill or “Wow, Tanks Really Suck”](https://docs.google.com/document/d/1rOlOdksd0QNTiAO2vLU6uYes0aAxGzFe1n5wuDdGmVg/edit)
 
-#### But the main points made in this sheet that we are trying to resolve with this playtest is:
+### But the main points made in this sheet that we are trying to resolve with this playtest is:
 
-- Full Tank is Bad. They invest all their level up points into health and defense stats, and it still only takes a glass cannon one maybe two turns to kill them, whilst they themselves deal no damage, because they have no points in attack/special attack. Meaning if you have two full tanks against eachother it is a wet noodle fight that can take **over 200 turns to resolve.**
+- Full Tank is Bad. They invest all their level up points into health and defense stats, and it still only takes a glass cannon one maybe two turns to kill them, whilst they themselves deal no damage, because they have no points in attack/special attack. Meaning if you have two full tanks against eachother it is a wet noodle fight that can take ***over 200 turns to resolve.***
 - Extreme agression stays consitant across all levels, with  most battles being over in two or less moves even with average rolls. In the case of two glass cannons going against eachother it can often just be down to whoever moves first wins. This is boring, and the opposite problem that we have with the tanks.
 - in the middle All Even builds progressively lose time as they level up as we've already established and they would be better off just focusing aggression
 - The idea of Base Stat Relations is that your pokemons stats should all increase gradually, as they level up. Even if you have a beefy snorlax their speed will still increase over time, regardless of if you're putting all your points in HP. This should be encouraged! and more well rounded pokemon should be rewarded and not felt like they are being left behind by the more specialised.
 
-### How does it work?
+## How does it work?
 To work out the new stat line of a pokemon we took some inspiration from the Generation III Calculation for the Pokémon games.
 
 ![image](https://user-images.githubusercontent.com/43385250/221129214-de5d5ff7-da5f-4da9-966a-c41a766ab102.png)
@@ -28,7 +28,7 @@ This can obviously look confusing, but the main changes from the current system 
 - When you assign level up points these will effectively be your pokemons EVs, and though they will not have an immediate impact early game, the impact of the EVs will scale with level. They are more of an investment than an immediate reward.
 - Nature is now applied to the final stat, rather than the Base stat as if the nature increases the stat it will increase the stat by 10%, and if the nature decreases the stat is will decrease the stat by 10%. Again this will not make much difference in the early levels, but will have a bigger impact at higher levels.
 
-#### What is that weird Squigly?
+### What is that weird Squigly?
 ![image](https://user-images.githubusercontent.com/43385250/221130475-8a0a894e-5c0f-4ee7-91f8-9683e8b7ac07.png)
 
 This section is what I refer to as the Sigma Modifier.
@@ -55,7 +55,7 @@ This effect also scales with level, so will have a higher impact in later levels
   Neither of these pokemon put any points into HP, but the generalised mon has a much higher HP stat at level 100.
  </details>
 
-#### Does this change acheives our objectives?
+### Does this change acheives our objectives?
 
 If we go back to the list of objectives that this change had:
 
@@ -79,11 +79,15 @@ Because this system scales with Base Stats a naturally fast pokemon, will always
 For example, Pikachu's highest base stat is speed, and it's lowest is defense. If you put all your level up points into defense because you want a chonky season 1 pikachu, not the skinny rubbish they brought out in later seasons, defense doesn't actually become the highest stat until level 20!
 
 
-### How can I take part?
+## How can I take part?
 If you want to play with these playtest stats the GM should go to the PTU Settings and click this checkbox.
 
 ![image](https://user-images.githubusercontent.com/43385250/221135503-476c39ec-6581-4db4-a362-6afd95e8b03d.png)
 
-I'd reccomend you let player re-allocate level up points if you do this, espcially if you are currently following the Base Stat Relations Rule.
+We recommend you to let player re-allocate level up points if you do this, espcially if you are currently following the Base Stat Relations Rule, as this one is now obsolete.
 
-Any feedback you have for how this new system plays out can be given to us in this [discord channel](https://discord.gg/Y8Wu2jZGzq)
+## Providing Feedback
+Feedback for any Playtest can be done in our [Discord Server's](https://discord.gg/Y8Wu2jZGzq) [#ptr-playtest](https://ptb.discord.com/channels/748601513835888682/1078480391448559718) discussions threads. All playtests will have their own 'Feedback' thread opened and marked as such.
+
+## FAQ
+None yet~

--- a/playtest.md
+++ b/playtest.md
@@ -1,10 +1,86 @@
 # Welcome to the Playtest!
 
 
-### What is this playtest
+### What is this playtest?
+This playtest is being used to gather feedback for a potential new system of calculating a pokemons statistics, it takes inspiration from the Gen III games.
 
-### Why
+### Why?
+The current system of **Base Stat Relations** is flawed. Many people completely ignore it and it has many issues with balancing, especially when comparing full tanks, vs 'glass cannons'. You can find full details of these issues written in this google docs sheet: https://docs.google.com/document/d/1rOlOdksd0QNTiAO2vLU6uYes0aAxGzFe1n5wuDdGmVg/edit
 
-### How it works
+#### But the main points made in this sheet that we are trying to resolve with this playtest is:
+
+- Full Tank is Bad. They invest all their level up points into health and defense stats, and it still only takes a glass cannon one maybe two turns to kill them, whilst they themselves deal no damage, because they have no points in attack/special attack. Meaning if you have two full tanks against eachother it is a wet noodle fight that can take **over 200 turns to resolve.**
+- Extreme agression stays consitant across all levels, with  most battles being over in two or less moves even with average rolls. In the case of two glass cannons going against eachother it can often just be down to whoever moves first wins. This is boring, and the opposite problem that we have with the tanks.
+- in the middle All Even builds progressively lose time as they level up as we've already established and they would be better off just focusing aggression
+- The idea of Base Stat Relations is that your pokemons stats should all increase gradually, as they level up. Even if you have a beefy snorlax their speed will still increase over time, regardless of if you're putting all your points in HP. This should be encouraged! and more well rounded pokemon should be rewarded and not felt like they are being left behind by the more specialised.
+
+### How does it work?
+To work out the new stat line of a pokemon we took some inspiration from the Generation III Calculation for the Pokémon games.
+
+![image](https://user-images.githubusercontent.com/43385250/221129214-de5d5ff7-da5f-4da9-966a-c41a766ab102.png)
+
+
+we have tweaked this calculation so that it works better for our game and helps acheive our objectives and now it looks like this
+![image](https://user-images.githubusercontent.com/43385250/221129633-cc843d34-7fdc-4331-97ea-b7476dc37859.png)
+
+This can obviously look confusing, but the main changes from the current system are
+- All stats now scale with level as well as how many points you put into them.
+- When you assign level up points these will effectively be your pokemons EVs, and though they will not have an immediate impact early game, the impact of the EVs will scale with level. They are more of an investment than an immediate reward.
+- Nature is now applied to the final stat, rather than the Base stat as if the nature increases the stat it will increase the stat by 10%, and if the nature decreases the stat is will decrease the stat by 10%. Again this will not make much difference in the early levels, but will have a bigger impact at higher levels.
+
+#### What is that weird Squigly?
+![image](https://user-images.githubusercontent.com/43385250/221130475-8a0a894e-5c0f-4ee7-91f8-9683e8b7ac07.png)
+
+This section is what I refer to as the Sigma Modifier.
+
+the σ symbol represents the standard deviation of the pokemons stats, before this modifier and the natures is applied. The basics of this is that the bigger the range of stats (say a glass cannon has put all 100 points into special attack) the bigger this σ value will be, which means that the fraction Level/100σ will be a much smaller number.
+In contrast to this if a player evenly distributes their stats the value of σ will be smaller, which means that the Sigma modifier will be bigger, and overall the total of their stats will actually by higher than the specialised glass cannon.
+This effect also scales with level, so will have a higher impact in later levels.
+
+<details>
+  <summary> Graphs showing this effect </summary>
+  
+  **A pokemon splitting their points into all stats except HP**
+  
+  ![image](https://user-images.githubusercontent.com/43385250/221131574-be92bad7-3f34-4ff9-b61a-cd5096d194e4.png)
+
+  Because their stat line is so close together they benefit a lot from the Sigma Modifier, meaning that each of there stats is increase by approximately 5 points by level 100.
+  
+  **A pokemon that puts all their points into def**
+  
+  ![image](https://user-images.githubusercontent.com/43385250/221131925-c2eb1eba-630f-413b-b12c-3c7e27e5f82a.png)
+
+  Because they will have a very high σ they benefit very little from the Sigma Modifier. This means that allthough they have the high defence they wanted, the rest of their stats will only scale with level.
+  
+  Neither of these pokemon put any points into HP, but the generalised mon has a much higher HP stat at level 100.
+ </details>
+
+#### Does this change acheives our objectives?
+
+If we go back to the list of objectives that this change had:
+
+**Full Tank was Bad.**
+-after doing some turns to kill calculations, using the same point distribution as in the above workbook we found that using this system Tanks take on average twice as long to be killed by the agressive glass cannons. They can actually tank now!
+-in addition to this the wet noodle fight of 200+ turns now does not occur, as the attack stats of the tank naturally increase it means that on average fights between full tanks will take around 10 turns if no super effective moves are used. This is obviously not as fast as if two glass cannons were to fight but still much better.
+
+**Glass cannons too stronk**
+- Glass cannons have been nerfed as part of this system. with average turns to kill being increased by a range of 1.5-2 times!
+- This means that Glass cannons are still powerful and can still kill other mon very quickly, but they will take some damage in the process and be less likely to sweep without the correct setup, clever use of Super Effective Moves, and a few lucky rolls.
+- In a fight between two glass cannons, it is still possible for one of them to one-shot the other, but it is no longer a consistant thing, it will rely on super effective moves, crits and high damage rolls. So when it does happen it should hopefully be more of a "WOW!" moment.
+
+**Even builds get left behind**
+As demonstrated above we've added the Sigma modifier to make it so that Even builds can be more of the Jack of all Trades. They get an increase to their stats so that a generalised pokemons stat total will actually be higher than the stat total of a glass cannon or a tank. This makes this playstyle much more viable.
+
+**The Essence of Base Stat Relations**
+-Because this system scales with Base Stats a naturally fast pokemon, will always be pretty fast, even with zero investment into the stat. This means that we can allow players to point level up points wherever they want without worrying about the essence of the pokemon being effected.
+-For example, Pikachu's highest base stat is speed, and it's lowest is defense. If you put all your level up points into defense because you want a chonky season 1 pikachu, not the skinny rubbish they brought out in later seasons, defense doesn't actually become the highest stat until level 20!
+
 
 ### How can I take part?
+If you want to play with these playtest stats the GM should go to the PTU Settings and click this checkbox.
+
+![image](https://user-images.githubusercontent.com/43385250/221135503-476c39ec-6581-4db4-a362-6afd95e8b03d.png)
+
+I'd reccomend you let player re-allocate level up points if you do this, espcially if you are currently following the Base Stat Relations Rule.
+
+Any feedback you have for how this new system plays out can be given to us in this [discord channel](https://discord.gg/Y8Wu2jZGzq)

--- a/templates/actor/character-sheet-gen8.hbs
+++ b/templates/actor/character-sheet-gen8.hbs
@@ -428,8 +428,8 @@
                     <div class="row no-gutters header">
                       <div class="col-sm-2 pt-2 pb-2 key stat-header">{{localize "PTU.StatsLabel"}}</div>
                       <div class="col-sm-2 mt-2 mb-2">{{localize "PTU.StatsBase"}}</div>
-                      <div class="col-sm-2 mt-2 mb-2">{{localize "PTU.StatsMod"}}</div>
                       <div class="col-sm-2 mt-2 mb-2" style="font-size: 9px;">{{localize "PTU.StatsLevelup"}}</div>
+                      <div class="col-sm-2 mt-2 mb-2">{{localize "PTU.StatsMod"}}</div>
                       <div class="col-sm-2 mt-2 mb-2">{{localize "PTU.StatsStage"}}</div>
                       <div class="col-sm-2 mt-2 mb-2">{{localize "PTU.StatsTotal"}}</div>
                     </div>
@@ -441,6 +441,16 @@
                       <div class="stats {{key}} base col-sm-2">
                         <input type="text" name="system.stats.{{key}}.value" value="{{stat.value}}" data-dtype="Number"
                           disabled />
+                      </div>                      
+                      <div class="stats {{key}} levelUp col-sm-2">
+                        {{> "systems/ptu/templates/partials/mod-field.hbs" 
+                          path=(concat "system.stats." key ".levelUp") 
+                          value=stat.levelUp
+                          dtype="Number" 
+                          mod=""
+                          total="ignored"
+                          modOrigins=(getProperty ../actor.origins (concat "system.stats." key ".levelUp"))
+                          flipped=(gt 3 @index)}}
                       </div>
                       <div class="stats {{key}} mod col-sm-2">
                         {{> "systems/ptu/templates/partials/mod-field.hbs" 
@@ -450,16 +460,6 @@
                           total="ignored"
                           dtype="Number" 
                           modOrigins=(getProperty ../actor.origins (concat "system.stats." key ".mod.mod"))
-                          flipped=(gt 3 @index)}}
-                      </div>
-                      <div class="stats {{key}} levelUp col-sm-2">
-                        {{> "systems/ptu/templates/partials/mod-field.hbs" 
-                          path=(concat "system.stats." key ".levelUp") 
-                          value=stat.levelUp
-                          dtype="Number" 
-                          mod=""
-                          total="ignored"
-                          modOrigins=(getProperty ../actor.origins (concat "system.stats." key ".levelUp"))
                           flipped=(gt 3 @index)}}
                       </div>
                       <div class="stats stage stage col-sm-2">

--- a/templates/actor/pokemon-sheet-gen8.hbs
+++ b/templates/actor/pokemon-sheet-gen8.hbs
@@ -41,8 +41,8 @@
                     <div class="row no-gutters header">
                       <div class="col-sm-2 pt-2 pb-2 key stat-header">{{localize "PTU.StatsLabel"}}</div>
                       <div class="col-sm-2 mt-2 mb-2">{{localize "PTU.StatsBase"}}</div>
-                      <div class="col-sm-2 mt-2 mb-2">{{localize "PTU.StatsMod"}}</div>
                       <div class="col-sm-2 mt-2 mb-2" style="font-size: 9px;">{{localize "PTU.StatsLevelup"}}</div>
+                      <div class="col-sm-2 mt-2 mb-2">{{localize "PTU.StatsMod"}}</div>
                       <div class="col-sm-2 mt-2 mb-2">{{localize "PTU.StatsStage"}}</div>
                       <div class="col-sm-2 mt-2 mb-2">{{localize "PTU.StatsTotal"}}</div>
                     </div>
@@ -54,17 +54,7 @@
                       <div class="stats {{key}} base col-sm-2">
                         <input type="text" name="data.stats.{{key}}.value" value="{{stat.value}}" data-dtype="Number"
                           disabled />
-                      </div>
-                      <div class="stats {{key}} mod col-sm-2">
-                        {{> "systems/ptu/templates/partials/mod-field.hbs"
-                        mod=stat.mod.mod
-                        path=(concat "data.stats." key ".mod.value")
-                        value=stat.mod.value
-                        total="ignored"
-                        dtype="Number"
-                        modOrigins=(getProperty ../origins (concat "system.stats." key ".mod.mod"))
-                        flipped=(gt 3 @index)}}
-                      </div>
+                      </div>                     
                       <div class="stats {{key}} levelUp col-sm-2">
                         {{> "systems/ptu/templates/partials/mod-field.hbs"
                         mod=""
@@ -73,6 +63,16 @@
                         dtype="Number"
                         total="ignored"
                         modOrigins=(getProperty ../origins (concat "system.stats." key ".levelUp"))
+                        flipped=(gt 3 @index)}}
+                      </div>
+                       <div class="stats {{key}} mod col-sm-2">
+                        {{> "systems/ptu/templates/partials/mod-field.hbs"
+                        mod=stat.mod.mod
+                        path=(concat "data.stats." key ".mod.value")
+                        value=stat.mod.value
+                        total="ignored"
+                        dtype="Number"
+                        modOrigins=(getProperty ../origins (concat "system.stats." key ".mod.mod"))
                         flipped=(gt 3 @index)}}
                       </div>
                       <div class="stats stage stage col-sm-2">


### PR DESCRIPTION
change total stat calculation to this:

![image](https://user-images.githubusercontent.com/43385250/221057344-cc0a912c-9372-40c6-b8eb-cb8eb1997026.png)

also rearranged the stat block columns because in this calculation level up points are applied before mod then finally stage to give the total stat.

![image](https://user-images.githubusercontent.com/43385250/221171200-661cde1f-9230-4ffc-b064-b84a77320045.png)
