### PR TITLE
Addressing Issue #319 and working towards #336

### DIFF
--- a/module/combat/effects/pokeball_effects.js
+++ b/module/combat/effects/pokeball_effects.js
@@ -532,6 +532,7 @@ export async function PlayReleaseOwnedPokemonAnimation(token) {
 
             await timeout(2000);
             await game.ptu.utils.species.playCry(actor.system.species);
+            await target_token.document.update({ "alpha": (1) });
 
 
             // alexander-r-block: Commenting out this block of code because the always_display_token_* properties are for wild pokemon.

--- a/module/combat/effects/pokeball_effects.js
+++ b/module/combat/effects/pokeball_effects.js
@@ -497,7 +497,7 @@ export async function PlayReleaseOwnedPokemonAnimation(token) {
             if(enable_pokeball_animation)
             {
                 // await target_token.document.update({ "alpha": (0) });
-                await game.ptu.utils.api.gm.updateToken(target_token, {alpha: 0})
+                await game.ptu.utils.api.gm.tokensUpdate(target_token, {alpha: 0})
             }
 
             await AudioHelper.play({src: pokeball_sound_paths["miss"], volume: 0.5, autoplay: true, loop: false}, true);
@@ -527,13 +527,16 @@ export async function PlayReleaseOwnedPokemonAnimation(token) {
                 // await target_token.TMFXaddUpdateFilters(pokeballShoop_params); 
                 await game.ptu.utils.api.gm.addTokenMagicFilters(target_token, game.canvas.scene, pokeballShoop_params);
                 // await target_token.document.update({ "alpha": (1) });
-                await game.ptu.utils.api.gm.updateToken(target_token, {alpha: 1})
+                await game.ptu.utils.api.gm.tokensUpdate(target_token, {alpha: 1})
             }
 
             await timeout(2000);
             await game.ptu.utils.species.playCry(actor.system.species);
 
-            if(always_display_token_name)
+
+            // alexander-r-block: Commenting out this block of code because the always_display_token_* properties are for wild pokemon.
+            //                    This also adds random bars to owned pokemon when using BarBrawl.
+            /* if(always_display_token_name)
             {
                 if(always_display_token_health == true)
                 {
@@ -563,7 +566,7 @@ export async function PlayReleaseOwnedPokemonAnimation(token) {
             else
             {
                 await target_token.document.update({ "alpha": (1) });
-            }
+            }*/
 
         }
         else if (actor.data.type == "pokemon") // Wild Pokemon - no pokeball release effect.

--- a/module/utils/item-piles-compatibility-handler.js
+++ b/module/utils/item-piles-compatibility-handler.js
@@ -42,7 +42,7 @@ export async function GetItemArt(item_name, type = ".webp") {
         return undefined;
     }
     return path;
-}
+} 
 
 
 Hooks.on("item-piles-preDropItemDetermined", function(a, b, dropped_item, d) {
@@ -67,7 +67,7 @@ Hooks.on("item-piles-preDropItemDetermined", function(a, b, dropped_item, d) {
 Hooks.on("item-piles-createItemPile", async function(created_token, options) {
 
     // check if the item pile being created is a pile or not (chest, vault, merchant are other possibilities)
-    let flags = created_token?.data?.actorData?.flags;
+    // let flags = created_token?.data?.actorData?.flags;
     
     // Set the name of the item pile to be either the name of the item, or a fallback generic name,
     // set the image (have to do it here, not earlier, since we can't do async fetches for item images
@@ -75,6 +75,7 @@ Hooks.on("item-piles-createItemPile", async function(created_token, options) {
     // marks the item pile as a token that should not have the usual tooltips.
     //
     // only activates if the pile is an item pile, and not if the pile is a chest, vault, or merchant
+    /*
     if(flags["item-piles"]?.data?.type == "pile") {
         let pile_name = created_token?.data?.actorData?.items?.[0]?.name ?? "Pile of Items";
         let new_image = await GetItemArt(pile_name);
@@ -83,6 +84,7 @@ Hooks.on("item-piles-createItemPile", async function(created_token, options) {
             "img": ( new_image )
         });
     }
+    */
     await created_token.update({
         "flags.token-tooltip-alt.noTooltip":true
     });


### PR DESCRIPTION
Fixing #319 by modifying `pokeball_effects.js`. Changes made:
- changed `game.ptu.utils.api.gm.updateToken` to `game.ptu.utils.api.gm.tokensUpdate`, as the former function no longer exists.
- commented out lines 536-566 in pre-changed file, moved `await target_token.document.update({ "alpha": (1) });` to line 535. The first change was made because
  - the settings `always_display_token_{name,health}` are meant for wild pokemon and shouldn't affect owned pokemon
  - when using the module BarBrawl, it added an extra health bar to the tokens with the above settings enabled
Second change was made to ensure token and bars are visible.

Working towards #336 by pushing changes made to my local machine that I have confirmed work. The tokens created for an ItemPile will now properly use the art in the compendium.