### PR TITLE
Update prototype token image when evolving

### DIFF
--- a/module/forms/charactermancer-pokemon-form.js
+++ b/module/forms/charactermancer-pokemon-form.js
@@ -220,7 +220,11 @@ export class PTUPokemonCharactermancer extends FormApplication {
         }
       }
     }
-    if(formData.imgPath) data.img = formData.imgPath;
+
+    if(formData.imgPath) {
+      data.img = formData.imgPath;
+      data['prototypeToken.texture.src'] = formData.imgPath;   
+    }
 
     log(`CHARACTERMANCER: Updating ${this.object.name}`, data);
     await this.object.update(data);


### PR DESCRIPTION
Fixes #291.

I also investigated updating active tokens but there wasn't a simple way to do it. The cleanest way would likely involve overriding `update` on the actor class, but that's a deeper change.

As I was writing up the PR, it occurred to me that this might be an undesirable breaking change for some people. I've had games in other systems (e.g. D&D, PF2E) where I intentionally used different images for actor "portraits" and tokens. However, I always use the same image for actor/token in my PTU games 🤷‍♂️ 