### PR TITLE
Move Speed Module now within system

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2248,6 +2248,29 @@ h3 {
   font-size: 12px;
   font-weight: bold;
 }
+/*****************
+* Movement Icons *
+*****************/
+.control-icon.chalk-icon {
+  width: fit-content;
+  min-width: 42px;
+  flex-basis: auto;
+  padding: 0 8px;
+  margin: 8px 15px 8px 0 !important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.control-icon.chalk-icon > * {
+  margin-right: 5px;
+}
+.chalk-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  flex: 0 !important;
+}
 .w-25 {
   width: 25% !important;
 }

--- a/css/ptu.less
+++ b/css/ptu.less
@@ -2726,3 +2726,30 @@ h3 {
     }
   } 
 }
+
+/*****************
+* Movement Icons *
+*****************/
+
+.control-icon.chalk-icon {
+	width: fit-content;
+	min-width: 42px;
+	flex-basis: auto;
+	padding: 0 8px;
+    margin: 8px 15px 8px 0 !important;
+	display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.control-icon.chalk-icon > * {
+    margin-right: 5px;
+}
+
+.chalk-container {
+	display: flex; 
+	flex-direction: row; 
+	justify-content: flex-end; 
+	align-items:center;
+	flex: 0 !important;
+}

--- a/module/ptu.js
+++ b/module/ptu.js
@@ -787,6 +787,51 @@ Hooks.on('getSceneControlButtons', function (hudButtons) {
 
 Hooks.on("renderTokenConfig", (config, html, options) => html.find("[name='actorLink']").siblings()[0].outerHTML = "<label>Link Actor Data <span class='readable p10'>Unlinked actors are not supported by the system</span></label>")
 
+/****************************
+Token Movement Info
+****************************/
+Hooks.on('renderTokenHUD', _addMovementIcons);
+
+function _addMovementIcons(app, html, data) {
+  if(!game.settings.get("ptu", "showMovementIcons")) return;
+
+    // Fetch Actor
+    const actor = game.actors.get(data.actorId);
+    if(actor === undefined) return;
+
+    // Ownership of actor does not need to be checked; token HUD only shows if you have control of said token.
+    
+    // List of capabilities to possibly display, and the icon it should use
+    const capabilitiesMap = {
+        Overland: "fas fa-shoe-prints",
+        Swim: "fas fa-swimmer",
+        Burrow: "fas fa-mountain",
+        Sky: "fas fa-feather",
+        Levitate: "fab fa-fly",
+        Teleporter: "fas fa-people-arrows",
+    }
+
+    const buttons = [];
+    for(const [cap,fac] of Object.entries(capabilitiesMap)) {
+        const val = actor.system.capabilities[cap];
+        // If value is 0 / unset no need to display.
+        if(!val) continue;
+        
+        buttons.push(`<div class="control-icon chalk-icon" title="${cap}: ${val}"><i class="${fac}"></i>${val}</div>`)
+    }
+
+    html.find(".col.middle").before( // if the actor uses a 2nd bar increase height.
+        `<div class="col middle" style="top: -${html.find(".bar2").html().trim() ? 105 : 90}px;">
+            <div class="chalk-container">
+                ${buttons.join("\n")}
+            </div>
+        </div>`
+    )
+
+}
+
+
+
 Hooks.on("preUpdateActor", async (oldActor, changes, options, sender) => {
   //check if this is turned off in settings
   const setting = game.settings.get("ptu", "levelUpScreen")

--- a/module/settings.js
+++ b/module/settings.js
@@ -793,6 +793,15 @@ export function LoadSystemSettings() {
             category: "playtest",
             onChange: debouncedReload
         })
+
+        game.settings.register("ptu", "showMovementIcons", {
+            name: "Show Movement Icons",
+            hint: "Show movement icons above controlled tokens.",
+            scope: "client",
+            config: true,
+            type: Boolean,
+            default: true
+        })
     }
 }
 


### PR DESCRIPTION
I have taken the code from my movement speed icons module and put it in the system. this can be turned off by each individual player in the player preferences options

![image](https://user-images.githubusercontent.com/43385250/227466548-51678eb2-4996-47fb-933d-855e9d1a1366.png)

example images:

![image](https://user-images.githubusercontent.com/43385250/227466844-039ed0b7-8118-4709-bb92-59e036f25eac.png)
![image](https://user-images.githubusercontent.com/43385250/227466922-8d3cd377-0a9d-41a6-8211-8ce9e54a02d1.png)
![image](https://user-images.githubusercontent.com/43385250/227466973-0b277815-83e9-4da3-ae34-90a73f3d9efa.png)
![image](https://user-images.githubusercontent.com/43385250/227467008-7bf9f535-f84a-44e3-95bd-de22652de412.png)
![image](https://user-images.githubusercontent.com/43385250/227467305-7a7d410d-bf70-4a96-a2bd-4dfa0cd7f885.png)


