### PR TITLE
Level-Up form Bugfixes

### DIFF
--- a/module/actor/calculations/stats-calculator.js
+++ b/module/actor/calculations/stats-calculator.js
@@ -7,17 +7,17 @@ export function CalcBaseStats(stats, speciesData, nature, baseStatModifier, igno
     const newStats = duplicate(stats);
 
     newStats.hp.base = CalcBaseStat(speciesData, nature, "HP", ignoreStages);
-    newStats.hp.value = baseStatModifier.hp.total + newStats.hp.base;
+    newStats.hp.value = (baseStatModifier?.hp.total ?? 0) + newStats.hp.base;
     newStats.atk.base = CalcBaseStat(speciesData, nature, "Attack", ignoreStages);
-    newStats.atk.value = baseStatModifier.atk.total + newStats.atk.base;
+    newStats.atk.value = (baseStatModifier?.atk.total ?? 0) + newStats.atk.base;
     newStats.def.base = CalcBaseStat(speciesData, nature, "Defense", ignoreStages);
-    newStats.def.value = baseStatModifier.def.total + newStats.def.base;
+    newStats.def.value = (baseStatModifier?.def.total ?? 0) + newStats.def.base;
     newStats.spatk.base = CalcBaseStat(speciesData, nature, "Special Attack", ignoreStages);
-    newStats.spatk.value = baseStatModifier.spatk.total + newStats.spatk.base;
+    newStats.spatk.value = (baseStatModifier?.spatk.total ?? 0)  + newStats.spatk.base;
     newStats.spdef.base = CalcBaseStat(speciesData, nature, "Special Defense", ignoreStages);
-    newStats.spdef.value = baseStatModifier.spdef.total + newStats.spdef.base;
+    newStats.spdef.value = (baseStatModifier?.spdef.total ?? 0)  + newStats.spdef.base;
     newStats.spd.base = CalcBaseStat(speciesData, nature, "Speed", ignoreStages);
-    newStats.spd.value = baseStatModifier.spd.total + newStats.spd.base;
+    newStats.spd.value = (baseStatModifier?.spd.total ?? 0)  + newStats.spd.base;
 
     return newStats;
 }

--- a/module/forms/level-up-form.js
+++ b/module/forms/level-up-form.js
@@ -109,8 +109,11 @@ export class PTULevelUpForm extends FormApplication {
     
     const missinghealth = oldHealthMax - oldHealthValue;
 
+    //adjust health as per level up
+    const newHealthTotal = 10 + state.changeDetails.newLvl + (state.stats.hp.newTotal * 3);
+    const newHealthMax = this.object.actor.system.health.injuries > 0 ? Math.trunc(newHealthTotal * (1 - ((this.object.actor.system.modifiers.hardened ? Math.min(this.object.actor.system.health.injuries, 5) : this.object.actor.system.health.injuries) / 10))) : newHealthTotal;
+    const newhealth = newHealthMax - missinghealth;
     
-
     const searchFor = (state.evolving.is && state.evolving.into) ? state.evolving.into.toLowerCase() : state.species.toLowerCase();
     const dexEntry = pokemonData.find(e => e._id.toLowerCase() === searchFor );
     let heightWidth = 1;
@@ -132,7 +135,8 @@ export class PTULevelUpForm extends FormApplication {
           "spatk.levelUp": (state.evolving.is ? 0 : state.stats.spatk.levelUp) + (state.stats.spatk.newLevelUp ?? 0),
           "spdef.levelUp": (state.evolving.is ? 0 : state.stats.spdef.levelUp) + (state.stats.spdef.newLevelUp ?? 0),
           "spd.levelUp": (state.evolving.is ? 0 : state.stats.spd.levelUp) + (state.stats.spd.newLevelUp ?? 0),
-        }
+        },
+        'health.value': newhealth
       },
       
       //only change the name if it is the same as the species and we are evolving
@@ -156,23 +160,10 @@ export class PTULevelUpForm extends FormApplication {
       data.img = imgPath;
       data.prototypeToken["texture.src"]= imgPath;
       token.document["texture.src"]= imgPath;
-    }
+    }  
 
     log(`Level-Up: Updating ${this.object.actor.name}`, data);
-    await this.object.actor.update(data);
-
-    //adjust health as per level up
-    const newHealthTotal = 10 + state.changeDetails.newLvl + (this.object.actor.system.stats.hp.total * 3);
-    const newHealthMax = this.object.actor.system.health.injuries > 0 ? Math.trunc(newHealthTotal * (1 - ((this.object.actor.system.modifiers.hardened ? Math.min(this.object.actor.system.health.injuries, 5) : this.object.actor.system.health.injuries) / 10))) : newHealthTotal;
-    const newhealth = newHealthMax - missinghealth;
-    const healthData = {
-      system: {
-        health: {
-          value: newhealth
-        }
-      }
-    };
-    await this.object.actor.update(healthData);
+    await this.object.actor.update(data);    
 
     // Determine which moves to delete
     const oldMoveNames = state.knownMoves.map(m => m?.name?.toLowerCase());


### PR DESCRIPTION
fixed a bug where level-up-points sometimes show as undefined if baseStatModifiers is undefined for any reason.

in the case that the modifier is undefined the system will now assume it to be 0, updating the actor should then (in theory) define the modifiers

I have also edited the way the missing health is calculated and applied so when a pokemon's maximum health goes up the amount of health they are missing stays the same as opposed to the current health staying the same. Current health will go up the same amount as max health.

Previous health calculation was causing an error in the _updateObject() function and causing it to not work when health of the mon changed.