### PR TITLE
+/- values into hp/exp fields

### DIFF
--- a/module/ptu.js
+++ b/module/ptu.js
@@ -792,7 +792,117 @@ Hooks.on('getSceneControlButtons', function (hudButtons) {
 Hooks.on("renderTokenConfig", (config, html, options) => html.find("[name='actorLink']").siblings()[0].outerHTML = "<label>Link Actor Data <span class='readable p10'>Unlinked actors are not supported by the system</span></label>")
 
 Hooks.on("preUpdateActor", async (oldActor, changes, options, sender) => {
-  //check if this is turned off in settings
+  
+  //check if xp changes are NaN
+  //check if xp changes start with + or - and if so increase/decrease value accordingly
+  const expChange = changes.system?.level?.exp;
+  if (expChange) {
+    const operator = expChange.charAt(0);
+    const amountStr = operator === '+' || operator === '-' ? expChange.substring(1) : expChange;
+    const amount = parseInt(amountStr);
+    if (!isNaN(amount)) {
+      const oldValue = oldActor.system.level.exp;
+      changes.system.level.exp = operator === '+' ? oldValue + amount
+                                                : operator === '-' ? oldValue - amount
+                                                                    : amount;
+    } else {
+      changes.system.level.exp = oldActor.system.level.exp;
+    }
+  } else {
+    changes.system.level.exp = oldActor.system.level.exp;
+  }
+
+  //milestones
+  const milestoneChange = changes.system?.level?.milestones;
+  if (milestoneChange) {
+    const operator = milestoneChange.charAt(0);
+    const amountStr = operator === '+' || operator === '-' ? milestoneChange.substring(1) : milestoneChange;
+    const amount = parseInt(amountStr);
+    if (!isNaN(amount)) {
+      const oldValue = oldActor.system.level.milestones;
+      changes.system.level.milestones = operator === '+' ? oldValue + amount
+                                                : operator === '-' ? oldValue - amount
+                                                                    : amount;
+    } else {
+      changes.system.level.milestones = oldActor.system.level.milestones;
+    }
+  } else {
+    changes.system.level.milestones = oldActor.system.level.milestones;
+  }
+
+  //miscExp
+  const miscExpChange = changes.system?.level?.miscexp;
+  if (miscExpChange) {
+    const operator = miscExpChange.charAt(0);
+    const amountStr = operator === '+' || operator === '-' ? miscExpChange.substring(1) : miscExpChange;
+    const amount = parseInt(amountStr);
+    if (!isNaN(amount)) {
+      const oldValue = oldActor.system.level.miscexp;
+      changes.system.level.miscexp = operator === '+' ? oldValue + amount
+                                                : operator === '-' ? oldValue - amount
+                                                                    : amount;
+    } else {
+      changes.system.level.miscexp = oldActor.system.level.miscexp;
+    }
+  } else {
+    changes.system.level.miscexp = oldActor.system.level.miscexp;
+  }
+  
+  //hp
+  const hpChange = changes.system?.health?.value;
+  if (hpChange) {
+    const operator = hpChange.charAt(0);
+    const amountStr = operator === '+' || operator === '-' ? hpChange.substring(1) : hpChange;
+    const amount = parseInt(amountStr);
+    if (!isNaN(amount)) {
+      const oldValue = oldActor.system.health.value;
+      changes.system.health.value = operator === '+' ? oldValue + amount
+                                                : operator === '-' ? oldValue - amount
+                                                                    : amount;
+    } else {
+      changes.system.health.value = oldActor.system.health.value;
+    }
+  } else {
+    changes.system.health.value = oldActor.system.health.value;
+  }  
+
+  //tempHp
+  const tempHpChange = changes.system?.tempHp?.value;
+  if (tempHpChange) {
+    const operator = tempHpChange.charAt(0);
+    const amountStr = operator === '+' || operator === '-' ? tempHpChange.substring(1) : tempHpChange;
+    const amount = parseInt(amountStr);
+    if (!isNaN(amount)) {
+      const oldValue = oldActor.system.tempHp.value;
+      changes.system.tempHp.value = operator === '+' ? oldValue + amount
+                                                : operator === '-' ? oldValue - amount
+                                                                    : amount;
+    } else {
+      changes.system.tempHp.value = oldActor.system.tempHp.value;
+    }
+  } else {
+    changes.system.tempHp.value = oldActor.system.tempHp.value;
+  }
+  
+  //tempHpMax
+  const tempHpMaxChange = changes.system?.tempHp?.max;
+  if (tempHpMaxChange) {
+    const operator = tempHpMaxChange.charAt(0);
+    const amountStr = operator === '+' || operator === '-' ? tempHpMaxChange.substring(1) : tempHpMaxChange;
+    const amount = parseInt(amountStr);
+    if (!isNaN(amount)) {
+      const oldValue = oldActor.system.tempHp.max;
+      changes.system.tempHp.max = operator === '+' ? oldValue + amount
+                                                : operator === '-' ? oldValue - amount
+                                                                    : amount;
+    } else {
+      changes.system.tempHp.max = oldActor.system.tempHp.max;
+    }
+  } else {
+    changes.system.tempHp.max = oldActor.system.tempHp.max;
+  }
+
+  //check if level up form is turned off in settings
   const setting = game.settings.get("ptu", "levelUpScreen")
   if(!setting) return; // option turned off by GM
 

--- a/templates/actor/character-sheet-gen8.hbs
+++ b/templates/actor/character-sheet-gen8.hbs
@@ -108,8 +108,7 @@
                       <div class="options w-100 d-flex">
                         <label for="progressBar" class="hp"></label>
                         <div class="d-flex pt-1 pb-1" style="text-align: center;">
-                          <input class="ml-1 mr-1" type="text" name="system.health.value" value="{{data.health.value}}"
-                            data-dtype="Number" />
+                          <input class="ml-1 mr-1" type="text" name="system.health.value" value="{{data.health.value}}" />
                           <span style="font-size: 20px;"> / </span>
                           <input class="ml-1" type="text" name="system.health.max" value="{{data.health.max}}" data-dtype="Number"
                             disabled />
@@ -118,9 +117,9 @@
                       <div class="options w-100 d-flex">
                         <div class="temp-hp"><label for="temp-hp">{{localize "PTU.HPTemp"}}</label></div>
                         <div class="d-flex pt-1 pb-1" style="text-align: center;">
-                          <input class="ml-1 mr-1" type="text" name="system.tempHp.value" value="{{data.tempHp.value}}" data-dtype="Number">
+                          <input class="ml-1 mr-1" type="text" name="system.tempHp.value" value="{{data.tempHp.value}}" >
                           <span style="font-size: 20px;"> / </span>
-                          <input class="ml-1" type="text" name="system.tempHp.max" value="{{data.tempHp.max}}" data-dtype="Number">
+                          <input class="ml-1" type="text" name="system.tempHp.max" value="{{data.tempHp.max}}" >
                         </div>
                       </div>
                       <div class="options w-100 pb-1 pt-1">
@@ -190,20 +189,20 @@
                           <div class="d-flex w-100 pt-1 pb-1" style="text-align: center;">
                             {{#if (is "true" (getGameSetting "useDexExp"))}}
                             <div class="col-sm-4">
-                              <input type="text" name="system.level.milestones" value="{{data.level.milestones}}" data-dtype="Number" />
+                              <input type="text" name="system.level.milestones" value="{{data.level.milestones}}" />
                             </div>
                             <div class="col-sm-4">
                               <input type="text" name="system.level.dexexp" value="{{data.level.dexexp}}" data-dtype="Number" disabled/>
                             </div>
                             <div class="col-sm-4">
-                              <input type="text" name="system.level.miscexp" value="{{data.level.miscexp}}" data-dtype="Number" />
+                              <input type="text" name="system.level.miscexp" value="{{data.level.miscexp}}" />
                             </div>
                             {{else}}
                               <div class="col-sm-6">
-                                <input type="text" name="system.level.milestones" value="{{data.level.milestones}}" data-dtype="Number" />
+                                <input type="text" name="system.level.milestones" value="{{data.level.milestones}}"/>
                               </div>
                               <div class="col-sm-6">
-                                <input type="text" name="system.level.miscexp" value="{{data.level.miscexp}}" data-dtype="Number" />
+                                <input type="text" name="system.level.miscexp" value="{{data.level.miscexp}}"/>
                               </div>
                             {{/if}}
                             </div>

--- a/templates/actor/pokemon-sheet-gen8.hbs
+++ b/templates/actor/pokemon-sheet-gen8.hbs
@@ -141,8 +141,7 @@
                       <div class="options w-100 d-flex">
                         <label for="progressBar" class="hp"></label>
                         <div class="d-flex pt-1 pb-1" style="text-align: center;">
-                          <input class="ml-1 mr-1" type="text" name="data.health.value" value="{{data.health.value}}"
-                            data-dtype="Number" />
+                          <input class="ml-1 mr-1" type="text" name="data.health.value" value="{{data.health.value}}"/>
                           <span style="font-size: 20px;"> / </span>
                           <input class="ml-1" type="text" name="data.health.max" value="{{data.health.max}}"
                             data-dtype="Number" disabled />
@@ -151,11 +150,9 @@
                       <div class="options w-100 d-flex">
                         <div class="temp-hp"><label for="temp-hp">{{localize "PTU.HPTemp"}}</label></div>
                         <div class="d-flex pt-1 pb-1" style="text-align: center;">
-                          <input class="ml-1 mr-1" type="text" name="data.tempHp.value" value="{{data.tempHp.value}}"
-                            data-dtype="Number">
+                          <input class="ml-1 mr-1" type="text" name="data.tempHp.value" value="{{data.tempHp.value}}"/>
                           <span style="font-size: 20px;"> / </span>
-                          <input class="ml-1" type="text" name="data.tempHp.max" value="{{data.tempHp.max}}"
-                            data-dtype="Number">
+                          <input class="ml-1" type="text" name="data.tempHp.max" value="{{data.tempHp.max}}"/>
                         </div>
                       </div>
                       <div class="options w-100 pb-1 pt-1">
@@ -254,8 +251,7 @@
                       <div class="swsh-body">
                         <div class="options w-100 d-flex">
                           <div class="d-flex w-100 pt-1 pb-1" style="text-align: center;">
-                            <input class="ml-1 mr-1" type="text" name="data.level.exp" value="{{data.level.exp}}"
-                              data-dtype="Number" />
+                            <input class="ml-1 mr-1" type="text" name="data.level.exp" value="{{data.level.exp}}" />
                             <span style="font-size: 20px;"> / </span>
                             <input class="ml-1" type="text" name="till-level-up" value="{{data.level.expTillNextLevel}}"
                               data-dtype="Number" disabled />


### PR DESCRIPTION
changed behaviour of the following fields

pokemon sheet:
![image](https://user-images.githubusercontent.com/43385250/229730327-8129b0a7-562c-4d61-93c8-8b0c17ebe55d.png)

character sheet:
![image](https://user-images.githubusercontent.com/43385250/229730206-7f25b8f7-f27d-4fb1-b6e1-83e40ed7ab0f.png)

now if you type in +x, or -x into the field, the current value with be increased or decreased by x.

you will still be able to directly enter a value to overwrite the value completely