### PR TITLE
Added a notes section to pokemon Extra Tab

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -192,6 +192,7 @@
     "PTU.Goals": "Goals",
     "PTU.Dreams": "Dreams",
     "PTU.Obsessions": "Obsessions",
+    "PTU.Notes": "Notes",
 
     "PTU.DexButtonName": "Pokédex",
     "PTU.DexButtonHint": "Scan the pokemon with your pokédex",

--- a/templates/actor/pokemon-sheet-gen8.hbs
+++ b/templates/actor/pokemon-sheet-gen8.hbs
@@ -1250,6 +1250,16 @@
                     </div>
                   </div>
                 </div>
+
+                <div class="swsh-box h-25 w-100 mb-2 red">
+                  <div class="swsh-header">
+                    <h3>{{localize "PTU.Notes"}}</h3>
+                  </div>
+                  <div class="swsh-body h-90">
+                    {{editor data.notes target="system.notes" button=true owner=owner editable=editable}}
+                  </div>
+                </div>
+                
               </div>
               <div class="col">
                 <!-- Skills -->


### PR DESCRIPTION
As per #303

I have added a notes section to the Extra tab on the pokemon page.

![image](https://user-images.githubusercontent.com/43385250/230124244-7478f346-a875-4e03-aa2b-6a91fc4bd68c.png)
