### PR TITLE
holding alt to give custom modifiers to ball throw

### DIFF
--- a/module/api/api.js
+++ b/module/api/api.js
@@ -128,7 +128,7 @@ export default class Api {
             async throwPokeballRequest(data) {
                 if (!ref._isMainGM()) return;
 
-                const {trainerName, pokemonName} = data.content;
+                const {trainerName, pokemonName, args} = data.content;
                 
                 if (!trainerName) return ref._returnBridge({ result: new ApiError({ message: "Trainer name not found.", type: 400 }) }, data);
                 if (!pokemonName) return ref._returnBridge({ result: new ApiError({ message: "Target pokemon name not found.", type: 400 }) }, data);
@@ -136,7 +136,10 @@ export default class Api {
                 const allowed = (game.settings.get("ptu", "pokeball-prompts") == 1 || game.settings.get("ptu", "pokeball-prompts") == 3) ? await new Promise((resolve, reject) => {
                     const dialog = new Dialog({
                         title: "Throw Pokéball?",
-                        content: `<p>It seems that ${trainerName} wishes to throw a ball at ${pokemonName}.<br>Will you let them?</p>`,
+                        content: `<p>It seems that ${trainerName} wishes to throw a ball at ${pokemonName}. <br>
+                            ${args.accuracyModifier != 0 ? "Custom Accuracy Modifier = " + args.accuracyModifier + '.<br>' : ""} 
+                            ${args.captureRateModifier != 0 ? "Custom Capture Rate Modifier = " + args.captureRateModifier + ".<br>" : ""}
+                            Will you let them?</p>`,
                         buttons: {
                             yes: {
                                 icon: '<i class="fas fa-check"></i>',
@@ -619,7 +622,7 @@ export default class Api {
      * @ApiError {403} - DM Denied request or Timed Out
      * @ApiError {400} - Badrequest, see message for details. 
      */
-    async throwPokeballRequest(trainerObject, pokemonObject, options) {
+    async throwPokeballRequest(trainerObject, pokemonObject, args, options) {
         let trainerActor;
         if (trainerObject instanceof game.ptu.config.Actor.documentClass)
             trainerActor = trainerObject;
@@ -646,7 +649,7 @@ export default class Api {
             return false;
         }
 
-        const content = { trainerName: trainerActor.name, pokemonName: pokemonActor.name, options };
+        const content = { trainerName: trainerActor.name, pokemonName: pokemonActor.name, args: args, options };
         return this._handlerBridge(content, "throwPokeballRequest", options?.timeout ?? 15000);
     }
 

--- a/module/combat/effects/pokeball_effects.js
+++ b/module/combat/effects/pokeball_effects.js
@@ -307,8 +307,7 @@ export async function ThrowPokeball(thrower, target, pokeball, args = { accuracy
 
     const POKEBALL_IMAGE_PATH = pokeball?.img ?? "systems/ptu/images/item_icons/basic ball.webp";
 
-    let accuracyBonus = args.accuracyModifier;
-    accuracyBonus += thrower?.data?.data?.modifiers?.acBonus?.total ?? 0;
+    const accuracyBonus = args?.accuracyModifier ?? 0 + thrower?.data?.data?.modifiers?.acBonus?.total ?? 0;
     // The only thing I know of that gives a bonus would be Tools of the Trade, +2AC
 
     function probablyHasToolsOfTheTrade(actor){

--- a/module/combat/effects/pokeball_effects.js
+++ b/module/combat/effects/pokeball_effects.js
@@ -280,7 +280,7 @@ let pokeballPolymorphFunc = async function (pokeball_image_path, target_token) {
 };
 
 
-export async function ThrowPokeball(thrower, target, pokeball) {
+export async function ThrowPokeball(thrower, target, pokeball, args = { accuracyModifier: 0, captureRateModifier: 0 }) {
     if (!target) {
         ui.notifications.error ("No target to throw pokeball at.");
         return false;
@@ -307,7 +307,8 @@ export async function ThrowPokeball(thrower, target, pokeball) {
 
     const POKEBALL_IMAGE_PATH = pokeball?.img ?? "systems/ptu/images/item_icons/basic ball.webp";
 
-    let accuracyBonus = thrower?.data?.data?.modifiers?.acBonus?.total ?? 0;
+    let accuracyBonus = args.accuracyModifier;
+    accuracyBonus += thrower?.data?.data?.modifiers?.acBonus?.total ?? 0;
     // The only thing I know of that gives a bonus would be Tools of the Trade, +2AC
 
     function probablyHasToolsOfTheTrade(actor){
@@ -362,7 +363,7 @@ export async function ThrowPokeball(thrower, target, pokeball) {
     {
         await PlayHitShakeAnimation(targetToken);
 
-        let captureData = await RollCaptureChance(thrower, target, pokeball.name, roll, targetToken);
+        let captureData = await RollCaptureChance(thrower, target, pokeball.name, roll, targetToken, args.captureRateModifier);
         const isCaptured = (Number(captureData.roll.total) <= captureData.rate) ? true : false;
 
         if ((game.modules.get("tokenmagic")?.active) && (game.settings.get("ptu", "enableMoveAnimations") == true))

--- a/module/utils/pokeball-capture-calculations.js
+++ b/module/utils/pokeball-capture-calculations.js
@@ -82,7 +82,7 @@ export function ActorHasItemWithName(actor, initial_item_name, item_category = "
 };
 
 
-export async function RollCaptureChance(trainer, target, pokeball, to_hit_roll, target_token) 
+export async function RollCaptureChance(trainer, target, pokeball, to_hit_roll, target_token, CaptureRollModifier) 
 {
 	const targetActor = target.actor;
 
@@ -93,7 +93,7 @@ export async function RollCaptureChance(trainer, target, pokeball, to_hit_roll, 
 	}
 
 	const captureData = {
-		rate: 100,
+		rate: 100 + CaptureRollModifier,
 		mod: -trainer.system.level.current
 	}
 

--- a/module/utils/pokeball-capture-calculations.js
+++ b/module/utils/pokeball-capture-calculations.js
@@ -94,7 +94,7 @@ export async function RollCaptureChance(trainer, target, pokeball, to_hit_roll, 
 
 	const captureData = {
 		rate: 100,
-		mod: -trainer.system.level.current + CaptureRollModifier
+		mod: -trainer.system.level.current + CaptureRollModifier ?? 0
 	}
 
 	// let CaptureRollModifier = 0;

--- a/module/utils/pokeball-capture-calculations.js
+++ b/module/utils/pokeball-capture-calculations.js
@@ -93,8 +93,8 @@ export async function RollCaptureChance(trainer, target, pokeball, to_hit_roll, 
 	}
 
 	const captureData = {
-		rate: 100 + CaptureRollModifier,
-		mod: -trainer.system.level.current
+		rate: 100,
+		mod: -trainer.system.level.current + CaptureRollModifier
 	}
 
 	// let CaptureRollModifier = 0;


### PR DESCRIPTION
on the sidebar if you hold alt whilst clicking a pokeball from the pokeball menu you will be given the following prompt.

![image](https://user-images.githubusercontent.com/43385250/236665637-f5e413bb-5404-4c49-855d-5867698f5e68.png)
(fields default to 0)

this allows user to enter custom accuracy and capture rate modifiers.
If the GM has the gm prompts enabled the GM will be informed of these modifiers.

![image](https://user-images.githubusercontent.com/43385250/236665679-9376c592-e1d7-472a-85de-127d8c29a0f1.png)

and these modifiers effect the accuracy and capture rate of pokeball throws

Before modifiers:
![image](https://user-images.githubusercontent.com/43385250/236665714-b8ba4a3b-85d6-4cba-b4ac-898e6bf86f8e.png)

After Modifiers:
![image](https://user-images.githubusercontent.com/43385250/236665769-87988047-fd5f-428b-a617-044bc93e0fe6.png)
