### PR TITLE
Basic Ranged Attacks

### DIFF
--- a/src/module/item/move/document.js
+++ b/src/module/item/move/document.js
@@ -27,7 +27,11 @@ class PTUMove extends PTUItem {
 
     /** @override */
     get realId() {
-        return this.system.isStruggle ? `struggle-${this.system.type.toLocaleLowerCase(game.i18n.lang)}-${this.system.category.toLocaleLowerCase(game.i18n.lang)}` : super.realId;
+        if (this.system.isStruggle){
+            return `struggle-${this.system.type.toLocaleLowerCase(game.i18n.lang)}-${this.system.category.toLocaleLowerCase(game.i18n.lang)}${this.system.isRangedStruggle?"-ranged":""}`
+        } else {
+            return super.realId
+        }
     }
 
     get isDamaging() {

--- a/src/module/item/move/document.js
+++ b/src/module/item/move/document.js
@@ -12,7 +12,7 @@ class PTUMove extends PTUItem {
     /** @override */
     get rollOptions() {
         const options = super.rollOptions;
-        if(this.isDamaging && this.damageBase.isStab && !!options.all[`move:damage-base:${this.damageBase.preStab}`]) {
+        if (this.isDamaging && this.damageBase.isStab && !!options.all[`move:damage-base:${this.damageBase.preStab}`]) {
             delete this.flags.ptu.rollOptions.all[`move:damage-base:${this.damageBase.preStab}`];
             delete this.flags.ptu.rollOptions.item[`move:damage-base:${this.damageBase.preStab}`];
 
@@ -27,11 +27,9 @@ class PTUMove extends PTUItem {
 
     /** @override */
     get realId() {
-        if (this.system.isStruggle){
-            return `struggle-${this.system.type.toLocaleLowerCase(game.i18n.lang)}-${this.system.category.toLocaleLowerCase(game.i18n.lang)}${this.system.isRangedStruggle?"-ranged":""}`
-        } else {
-            return super.realId
-        }
+        return this.system.isStruggle
+            ? `struggle-${this.system.type.toLocaleLowerCase(game.i18n.lang)}-${this.system.category.toLocaleLowerCase(game.i18n.lang)}${this.system.isRangedStruggle ? "-ranged" : ""}`
+            : super.realId;
     }
 
     get isDamaging() {
@@ -43,7 +41,7 @@ class PTUMove extends PTUItem {
     }
 
     get damageBase() {
-        if(!this.isDamaging) return null;
+        if (!this.isDamaging) return null;
         const result = {
             preStab: isNaN(Number(this.system.damageBase)) ? 0 : Number(this.system.damageBase),
             postStab: 0,
@@ -57,7 +55,7 @@ class PTUMove extends PTUItem {
     /** @override */
     prepareBaseData() {
         super.prepareBaseData();
-        
+
         const rollOptions = {
             all: {
                 [`move:type:${sluggify(this.system.type)}`]: true,
@@ -65,51 +63,51 @@ class PTUMove extends PTUItem {
                 [`move:frequency:${sluggify(this.system.frequency)}`]: true,
             }
         }
-        
+
         const ranges = this.system.range?.split(",").map(r => r.trim()) ?? [];
-        for(const range of ranges) {
+        for (const range of ranges) {
             rollOptions.all[`move:range:${sluggify(range)}`] = true;
         }
-        
-        if(this.isDamaging) {
+
+        if (this.isDamaging) {
             rollOptions.all[`move:damage-base:${this.damageBase.postStab}`] = true;
             rollOptions.all[`move:damage-base:pre-stab:${this.damageBase.preStab}`] = true;
         }
-        if(!isNaN(Number(this.system.ac))) rollOptions.all[`move:ac:${this.system.ac}`] = true;
+        if (!isNaN(Number(this.system.ac))) rollOptions.all[`move:ac:${this.system.ac}`] = true;
         rollOptions.item = rollOptions.all;
-        
-        this.flags.ptu = mergeObject(this.flags.ptu, {rollOptions});
+
+        this.flags.ptu = mergeObject(this.flags.ptu, { rollOptions });
     }
 
     /** @override */
     async use(options = {}) {
-        if(this.isDamaging || this.system.frequency === "Static") return;
+        if (this.isDamaging || this.system.frequency === "Static") return;
 
         let didSomething = false;
         const conditions = new Set(this.actor.getFilteredRollOptions("condition"))
-        if(conditions.has("condition:confused")) {
+        if (conditions.has("condition:confused")) {
             await PTUCondition.HandleConfusion(this, this.actor);
             didSomething = true;
         }
 
-        if(this.referenceEffect) {
+        if (this.referenceEffect) {
             const results = [];
             const effect = await fromUuid(this.referenceEffect);
-            if(this.range.includes("Self")) {
+            if (this.range.includes("Self")) {
                 const result = await effect.apply([this.actor], this.actor);
-                if(result) results.push(...result);
+                if (result) results.push(...result);
             }
             else {
                 const targets = options.targets || [...game.user.targets] || canvas.tokens.controlled;
                 const result = await effect.apply(targets, this.actor);
-                if(result) results.push(...result);
+                if (result) results.push(...result);
             }
 
-            if(results.length > 0) {
-                const statements = results.map((effect) => 
-                    game.i18n.format("PTU.Broadcast.ApplyEffect", {actor: effect.actor.link, effect: effect.link, source: this.actor.link})
+            if (results.length > 0) {
+                const statements = results.map((effect) =>
+                    game.i18n.format("PTU.Broadcast.ApplyEffect", { actor: effect.actor.link, effect: effect.link, source: this.actor.link })
                 ).filter(s => s).join("<br/>")
-                const enrichedHtml = await TextEditor.enrichHTML(statements, {async: true})
+                const enrichedHtml = await TextEditor.enrichHTML(statements, { async: true })
                 const chatData = {
                     user: game.user.id,
                     speaker: ChatMessage.getSpeaker({ actor: this.actor }),
@@ -121,8 +119,8 @@ class PTUMove extends PTUItem {
                 didSomething = true;
             }
         }
-        
-        if(!didSomething) {
+
+        if (!didSomething) {
             ui.notifications.warn(game.i18n.localize("PTU.Notifications.NoEffect"));
         }
     }


### PR DESCRIPTION
#491 
- Feature
  - Basic Ranged Attacks grant Struggles with Range 6
  - Use Roll Option with domain `struggle`, option `<yourtype>:ranged` and empty value to grant Ranged Struggles to your custom types
  - The Basic Ranged Attacks Capability with a Choice Set of all RAW Types except Normal to choose from, including slightly changed wording to reflect that it can be used for any typed Struggle, not only with the original Capabilites Firestarter, etc. But the wording is very likely still improvable.
    - [fvtt-Item-basic-ranged-attacks-7qIhLGmpYQii8MG5.json](https://github.com/dylanpiera/Foundry-Pokemon-Tabletop-United-System/files/13255404/fvtt-Item-basic-ranged-attacks-7qIhLGmpYQii8MG5.json)
  - Since it was useful for testing - an Effect that changes the Skill used to calculate Struggle Stats
    - [fvtt-Item-effect_-custom-struggle-skill-8vNg2qFtRQqy1f7y.json](https://github.com/dylanpiera/Foundry-Pokemon-Tabletop-United-System/files/13255400/fvtt-Item-effect_-custom-struggle-skill-8vNg2qFtRQqy1f7y.json)
- Tech
  - Most work was cleaning up the method granting struggles, generalizing to reduce code/data duplication, getting constant data out of loops and such.
  - Added `move.system.isRangedStruggle = true` to Ranged Struggle Moves, currently used by `PTUMove.realId()`
  - I updated `PTUMove.realId()` to also add `-ranged` to the fake-ish realId for struggles to allow for differentiation. If one would want to have both ranged and melee struggles in their list, their IDs must differ. 
