### PR TITLE
Fixed using massiveDamageThresholdPercent twice

### DIFF
--- a/src/module/actor/base.js
+++ b/src/module/actor/base.js
@@ -540,7 +540,7 @@ class PTUActor extends Actor {
             const { health } = this.system;
 
             const massiveDamageGatePercentage = game.settings.get("ptu", "automation.massiveDamageThresholdPercent")
-            const maxHpInjuryIntervalPercentage = game.settings.get("ptu", "automation.massiveDamageThresholdPercent")
+            const maxHpInjuryIntervalPercentage = game.settings.get("ptu", "automation.hpInjuryGateIntervalPercent")
 
             if (hpDamage >= Math.floor(health.total * massiveDamageGatePercentage / 100)) {
                 injuries++;


### PR DESCRIPTION
And one observation of barely and real practical significance:
If the Injury Interval is <= 1%, it does not apply any injuries due to the way that Injuries are calculated. I personally do not see a need to fix that.