### PR TITLE
Call taggify once after rendering

### DIFF
--- a/src/module/item/sheet/rule-elements/ae-like-form.js
+++ b/src/module/item/sheet/rule-elements/ae-like-form.js
@@ -1,5 +1,4 @@
 import { isObject } from '../../../../util/misc.js';
-import { tagify } from '../../../../util/tags.js';
 import { isBracketedValue } from '../../../rules/rule-element/base.js';
 import { RuleElementForm } from './base.js'
 

--- a/src/module/item/sheet/rule-elements/effectiveness-form.js
+++ b/src/module/item/sheet/rule-elements/effectiveness-form.js
@@ -1,4 +1,3 @@
-import { tagify } from '../../../../util/tags.js';
 import { RuleElementForm } from './base.js'
 
 class EffectivenessForm extends RuleElementForm {

--- a/src/module/item/sheet/rule-elements/ephemeral-effect-form.js
+++ b/src/module/item/sheet/rule-elements/ephemeral-effect-form.js
@@ -1,4 +1,3 @@
-import { tagify } from '../../../../util/tags.js';
 import { RuleElementForm } from './index.js';
 
 class EphemeralEffectForm extends RuleElementForm {

--- a/src/module/item/sheet/rule-elements/flat-modifier-form.js
+++ b/src/module/item/sheet/rule-elements/flat-modifier-form.js
@@ -1,5 +1,4 @@
 import { isObject } from '../../../../util/misc.js';
-import { tagify } from '../../../../util/tags.js';
 import { isBracketedValue } from '../../../rules/rule-element/base.js';
 import { RuleElementForm } from './base.js'
 

--- a/src/module/item/sheet/rule-elements/grant-item-form.js
+++ b/src/module/item/sheet/rule-elements/grant-item-form.js
@@ -1,4 +1,3 @@
-import { tagify } from '../../../../util/tags.js';
 import { RuleElementForm } from './index.js';
 
 class GrantItemForm extends RuleElementForm {

--- a/src/module/item/sheet/sheet.js
+++ b/src/module/item/sheet/sheet.js
@@ -105,10 +105,6 @@ class PTUItemSheet extends ItemSheet {
     activateListeners(html) {
         super.activateListeners(html);
 
-        for(const taggifyElement of html.find(".ptu-tagify")) {
-            tagify(taggifyElement);
-        }
-
         html.find('select[data-action=select-rule-element]').on('change', (event) => {
             this.selectedRuleElementType = event.target.value;
         });

--- a/src/scripts/hooks/index.js
+++ b/src/scripts/hooks/index.js
@@ -7,6 +7,7 @@ import { Ready } from "./ready.js";
 import { DeleteToken } from "./tokenDocumentDeleted.js";
 import { AutocompleteInlinePropertiesSetup } from "./aip-setup.js";
 import { GetSceneControlButtons } from "./get-scene-control-buttons.js";
+import { TagifySheets } from "./tagify-sheets.js";
 
 export const PtuHooks = {
     listen() {
@@ -20,7 +21,8 @@ export const PtuHooks = {
             Ready,
             DeleteToken,
             AutocompleteInlinePropertiesSetup,
-            GetSceneControlButtons
+            GetSceneControlButtons,
+            TagifySheets
         ]
         for(const listener of listeners) listener.listen();
     }

--- a/src/scripts/hooks/tagify-sheets.js
+++ b/src/scripts/hooks/tagify-sheets.js
@@ -1,0 +1,11 @@
+import {tagify} from "../../util/tags.js";
+
+export const TagifySheets = {
+    listen: () => {
+        Hooks.on("renderPTUItemSheet", (sheet, $html) => {
+            for(const taggifyElement of $html.find(".ptu-tagify")) {
+                tagify(taggifyElement);
+            }
+        });
+    },
+};


### PR DESCRIPTION
Should behave exactly as 4.0.8, but allows further development without fighting side effects.

Could not find difference in behaviour with Edges, Features, RuleElements while editable, uneditable, or reading-only view.