### PR TITLE
sluggifying class for filtering Feats and adding pretty alternative for display

### DIFF
--- a/src/module/apps/compendium-browser/tabs/feats.js
+++ b/src/module/apps/compendium-browser/tabs/feats.js
@@ -43,7 +43,7 @@ export class CompendiumBrowserFeatsTab extends CompendiumBrowserTab {
                 if (source) sources.add(source);
 
                 const isClass = featData.img.includes("class");
-                const _class = isClass ? featData.name.trim().toLowerCase().capitalize() : (featData.system.class?.trim()?.toLowerCase()?.capitalize() ?? "");
+                const _class = isClass ? featData.name.trim(): (featData.system.class?.trim() ?? "");
                 const prerequisites = featData.system?.prerequisites ?? "";
 
                 feats.push({
@@ -53,7 +53,8 @@ export class CompendiumBrowserFeatsTab extends CompendiumBrowserTab {
                     uuid: `Compendium.${pack.collection}.${featData._id}`,
                     source: sourceSlug,
                     prerequisites: this.#prerequisitesStringToEntries(prerequisites),
-                    class: _class,
+                    class: sluggify(_class),
+                    classPretty: _class,
                 })
                 if (_class) classes.add(_class);
 
@@ -107,7 +108,7 @@ export class CompendiumBrowserFeatsTab extends CompendiumBrowserTab {
     #generateCheckboxOptions(classSet) {
         return classSet.reduce((result, _class) => ({
             ...result,
-            [_class.toLowerCase()]: {
+            [sluggify(_class)]: {
                 label: _class,
                 selected: false
             }

--- a/static/templates/apps/compendium-browser/partials/feats.hbs
+++ b/static/templates/apps/compendium-browser/partials/feats.hbs
@@ -6,7 +6,7 @@
         <a class="item-link">{{entry.name}}</a>
     </div>
     <div class="tags">
-        {{#if entry.class}}<span class="tag class class-{{entry.class}}" title="{{entry.class}}">{{entry.class}}</span>{{/if}}
+        {{#if entry.class}}<span class="tag class class-{{entry.class}}" title="{{entry.class}}">{{entry.classPretty}}</span>{{/if}}
         {{#each entry.prerequisites as |entry|}}
             {{#if entry.tier}}
                 <span class="tag skill-{{toLowerCase entry.tier}}" title="{{entry.label}}">{{entry.label}}</span>


### PR DESCRIPTION
changes data of classes in filterData to sluggified version. previously, keys like "Ace trainer [cr]" were present, prohibiting creation of @CompSearch entries for them.

added classPretty to featItem in FeatsBrowser for fancy display in hbs partial. (From "Ace trainer [cr]" to "Ace Trainer [CR]")