### PR TITLE
Fix the resolution of the roll mode logic in check.js

### DIFF
--- a/src/module/system/check/check.js
+++ b/src/module/system/check/check.js
@@ -163,7 +163,7 @@ class PTUDiceCheck {
         
         const skipDialog  = skipDialogArg ?? eventToRollParams(this.event).skipDialog;
 
-        const rollMode = rollModeArg ?? this.options.has("secret") ? (game.user.isGM ? "gmroll" : "blindroll") : "roll";
+        const rollMode = rollModeArg ?? (this.options.has("secret") ? (game.user.isGM ? "gmroll" : "blindroll") : "roll");
 
         const dialogContext = await (async () => {
             if (skipDialog) return {


### PR DESCRIPTION
There was a subtle bug here regarding the high precedence of the ?? operator that caused all rolls with a `rollModeArg` set to be incorrectly rolled as a gmroll or blindroll, regardless of its actual setting.

Fixes #797