### PR TITLE
805: NPC Builder Improvements 1

### DIFF
--- a/src/module/apps/npc-quick-build/document.js
+++ b/src/module/apps/npc-quick-build/document.js
@@ -728,7 +728,7 @@ export class NpcQuickBuildData {
             shiny: false,
             nickname: "",
             level: {
-                value: game.settings.get("ptu", "generation.defaultDexDragInLevelMin"), // TODO: use a different default? Maybe 2x trainer level?
+                value: this.trainer.level * 2,
                 min: 1,
                 max: 100,
             }

--- a/src/module/apps/npc-quick-build/document.js
+++ b/src/module/apps/npc-quick-build/document.js
@@ -156,7 +156,7 @@ export class NpcQuickBuildData {
             updated: false,
             options: [
                 { label: "Compendium Browser Settings", uuid: "" },
-                ...game.tables.map(t => ({ label: t.name, uuid: t.uuid }))
+                ...game.tables.map(t => ({ label: t.name, uuid: t.uuid, group: t.folder?.name }))
             ],
             link: {
                 label: undefined,

--- a/src/module/apps/npc-quick-build/document.js
+++ b/src/module/apps/npc-quick-build/document.js
@@ -126,42 +126,7 @@ export class NpcQuickBuildData {
 
         this.party = {};
         for (let n = 1; n <= MaxPartyPokemon; n++) {
-            this.party[`slot${n}`] = {
-                slot: `slot${n}`,
-                configured: false,
-                species: {
-                    object: null,
-                    name: "",
-                    img: "icons/svg/mystery-man.svg",
-                    uuid: "",
-                    selected: [],
-                    gender: {
-                        selected: "",
-                        options: [],
-                        choosable: false,
-                    },
-                    variations: {
-                        selected: "",
-                        options: [],
-                    },
-                    optimization: {
-                        selected: "good",
-                        options: [
-                            { label: "PTU.OptimizationLevel.Bad", value: "bad" },
-                            { label: "PTU.OptimizationLevel.Neutral", value: "neutral" },
-                            { label: "PTU.OptimizationLevel.Good", value: "good" },
-                            { label: "PTU.OptimizationLevel.MinMaxed", value: "minmax" },
-                        ]
-                    },
-                },
-                shiny: false,
-                nickname: "",
-                level: {
-                    value: game.settings.get("ptu", "generation.defaultDexDragInLevelMin"), // TODO: use a different default? Maybe 2x trainer level?
-                    min: 1,
-                    max: 100,
-                }
-            };
+            this.resetPokemonSlot(`slot${n}`);
         }
 
         this.multiselects = {
@@ -294,8 +259,8 @@ export class NpcQuickBuildData {
     }
 
     /*-----------------------------------------------------------------------*/
-
     /*                           AUTO GENERATION                             */
+    /*-----------------------------------------------------------------------*/
 
     async randomizeAll(force = false) {
         if (force) this.manuallyUpdatedFields = new Set();
@@ -673,6 +638,12 @@ export class NpcQuickBuildData {
     }
 
 
+    
+
+    /*-----------------------------------------------------------------------*/
+    /*                        Party Pokemon Settings                         */
+    /*-----------------------------------------------------------------------*/
+
     async configurePokemonSpecies(slot, { species, uuid }) {
         const pkmn = this.party[slot];
 
@@ -724,6 +695,47 @@ export class NpcQuickBuildData {
 
         this.party[slot].configured = true;
     }
+
+    async resetPokemonSlot(slot) {
+        this.party[slot] = {
+            slot,
+            configured: false,
+            species: {
+                object: null,
+                name: "",
+                img: "icons/svg/mystery-man.svg",
+                uuid: "",
+                selected: [],
+                gender: {
+                    selected: "",
+                    options: [],
+                    choosable: false,
+                },
+                variations: {
+                    selected: "",
+                    options: [],
+                },
+                optimization: {
+                    selected: "good",
+                    options: [
+                        { label: "PTU.OptimizationLevel.Bad", value: "bad" },
+                        { label: "PTU.OptimizationLevel.Neutral", value: "neutral" },
+                        { label: "PTU.OptimizationLevel.Good", value: "good" },
+                        { label: "PTU.OptimizationLevel.MinMaxed", value: "minmax" },
+                    ]
+                },
+            },
+            shiny: false,
+            nickname: "",
+            level: {
+                value: game.settings.get("ptu", "generation.defaultDexDragInLevelMin"), // TODO: use a different default? Maybe 2x trainer level?
+                min: 1,
+                max: 100,
+            }
+        };
+    }
+
+
 
 
     /**

--- a/src/module/apps/npc-quick-build/document.js
+++ b/src/module/apps/npc-quick-build/document.js
@@ -198,6 +198,7 @@ export class NpcQuickBuildData {
                     value: feature.name,
                     uuid: feature.uuid,
                     prerequisites: feature?.system?.prerequisites ?? [],
+                    class: feature?.system?.class,
                 })
             }
         }
@@ -999,6 +1000,9 @@ export class NpcQuickBuildData {
 
     async refresh() {
         const unlock = await this._refreshMutex.lock()
+
+        this.multiselects = foundry.utils.deepClone(this._staticMultiselects);
+        
         // grab the features and prerequisites
         // the actual structure of these foundry items, plus "uuid" and "auto"
         const allComputed = [];
@@ -1226,6 +1230,14 @@ export class NpcQuickBuildData {
             }
             this.multiselects[key].options = multiselectOptions;
         }
+        // Sort the features and add classifiers (from currently selected classes, etc)
+        const selectedClasses = this.trainer.classes.selected.map(c=>c.value);
+        for (const featureOption of this.multiselects.features.options) {
+            featureOption.crossClass = (selectedClasses.length > 0 && featureOption?.class) ? !selectedClasses.includes(featureOption.class) : false;
+        }
+        this.multiselects.features.options.sort((a, b)=> a.crossClass - b.crossClass || a.label.localeCompare(b.label));
+        
+        this.multiselects.edges.options.sort((a, b)=> a.label.localeCompare(b.label));
 
         unlock();
     }

--- a/src/module/apps/npc-quick-build/document.js
+++ b/src/module/apps/npc-quick-build/document.js
@@ -1101,14 +1101,16 @@ export class NpcQuickBuildData {
                 const uuid = choice.uuid;
                 const label = choice.label ?? choice.name;
                 const key = `${label}-${idx}`.replaceAll(".", "-");
+                const original = this.trainer?.subSelectables?.[key];
+                const selected = original?.visible ? original?.selected ?? null : null;
                 const subSelectable = {
                     key,
                     uuid,
                     label,
                     idx,
                     choices,
-                    selected: this.trainer?.subSelectables?.[key]?.selected ?? null,
-                    visible: this.trainer?.subSelectables?.[key]?.visible ?? true,
+                    selected,
+                    visible: true,
                 };
                 // check if the choices are items in the compendium
                 if (choices.every(c => COMPENDIUM_ITEM_RE.test(c.value))) {
@@ -1320,7 +1322,7 @@ export class NpcQuickBuildData {
                 // iobj.flags.ptu ??= {}
                 // iobj.flags.ptu.rulesSelections ??= {}
                 for (const [idx, choiceSet] of choiceSets.entries()) {
-                    const label = item.label;
+                    const label = item.label ?? item.name;
                     const key = `${label}-${idx}`.replaceAll(".", "-");
                     choiceSet.selection = this.trainer.subSelectables[key].selected;
                 }

--- a/src/module/apps/npc-quick-build/sheet.js
+++ b/src/module/apps/npc-quick-build/sheet.js
@@ -143,6 +143,16 @@ export class PTUNpcQuickBuild extends FormApplication {
             });
         }
 
+        // "remove pokemon" button
+        $html.find('.pokemon-remove').on('click', function (event) {
+            event.preventDefault();
+            // if (event.target.disabled) return;
+            // event.target.disabled = true;
+            const dataset = this.closest(".party-pokemon")?.dataset;
+            globalThis.data.resetPokemonSlot(dataset?.slot);
+            globalThis.render(true);
+        });
+
         // $html.find('.tab-button').on('click', (event) => {
         //     event.preventDefault();
 

--- a/src/module/apps/npc-quick-build/sheet.js
+++ b/src/module/apps/npc-quick-build/sheet.js
@@ -114,6 +114,13 @@ export class PTUNpcQuickBuild extends FormApplication {
                 tagifyOptions.enforceWhitelist = false;
             }
 
+            if (multiselect.matches(".trainer-features")) {
+                tagifyOptions.templates ??= {};
+                tagifyOptions.templates.dropdownItem = function(tagData) {
+                    return `<div label="${tagData.label}" value="${tagData.value}" uuid="${tagData.uuid}" mappedvalue="${tagData.mappedValue}" class="tagify__dropdown__item ${tagData.label} ${tagData.crossClass ? "crossclass" : ""}" tabindex="0" role="option">${tagData.label}</div>`
+                };
+            }
+
             const tagify = new Tagify(multiselect, tagifyOptions);
 
             // // Add the name to the tags html as an indicator for refreshing

--- a/src/module/apps/npc-quick-build/sheet.js
+++ b/src/module/apps/npc-quick-build/sheet.js
@@ -94,9 +94,8 @@ export class PTUNpcQuickBuild extends FormApplication {
             // await tagify(element);
             const data = this.data.multiselects[multiselect.dataset.filterName];
             const savePath = multiselect.name;
-
-            const tagify = new Tagify(multiselect, {
-                enforceWhitelist: !multiselect.matches(".trainer-sex"),
+            const tagifyOptions = {
+                enforceWhitelist: true,
                 keepInvalidTags: false,
                 editTags: false,
                 tagTextProp: "label",
@@ -109,7 +108,13 @@ export class PTUNpcQuickBuild extends FormApplication {
                 },
                 whitelist: data.options,
                 maxTags: data.maxTags,
-            });
+            };
+
+            if (multiselect.matches(".trainer-sex")) {
+                tagifyOptions.enforceWhitelist = false;
+            }
+
+            const tagify = new Tagify(multiselect, tagifyOptions);
 
             // // Add the name to the tags html as an indicator for refreshing
             // if (multiselect.name) {

--- a/src/module/apps/npc-quick-build/sheet.js
+++ b/src/module/apps/npc-quick-build/sheet.js
@@ -169,22 +169,16 @@ export class PTUNpcQuickBuild extends FormApplication {
             const dataset = this.closest(".party-pokemon")?.dataset;
             await globalThis.loading();
             await globalThis.data.randomizePartyPokemon(dataset?.slot);
-            await globalThis.render(true);
+            globalThis.render(true);
         });
 
-        // $html.find('.tab-button').on('click', (event) => {
-        //     event.preventDefault();
+        $html.find("#sourceSelect").on("change", function (event) {
+            event.preventDefault();
+            globalThis.data.sourceSelect.value = this?.value;
+            globalThis.data.sourceSelect.updated = true;
 
-        //     this.data.speciesTab = event.currentTarget.dataset.tab;
-        //     this.render(true);
-        // });
-
-        // $html.find("#tableSelect").on("change", (event) => {
-        //     this.data.tableSelect.value = event.currentTarget.value;
-        //     this.data.tableSelect.updated = true;
-
-        //     this.render(true);
-        // });
+            globalThis.render(true);
+        });
 
         $html.find("input.submit[type='button']").on("click", (event) => {
             event.preventDefault();

--- a/src/module/apps/npc-quick-build/sheet.js
+++ b/src/module/apps/npc-quick-build/sheet.js
@@ -303,7 +303,15 @@ export class PTUNpcQuickBuild extends FormApplication {
     /** @override */
     async close(options) {
         if (options?.properClose) {
-            await this.data.finalize().then(()=>this.data.generate());
+            await this.data.finalize().then(()=>this.data.generate()).catch(err => {
+                ui.notifications.error("Could not generate the NPC! Check the dev console for more details.");
+                Hooks.onError("Application#close", err, {
+                    msg: `An error occurred while closing ${this.constructor.name} ${this.appId}`,
+                    log: "error",
+                    ...options
+                });
+                return this.unloading();
+            });;
         }
 
         return super.close({ ...options, force: true });

--- a/src/module/apps/npc-quick-build/sheet.js
+++ b/src/module/apps/npc-quick-build/sheet.js
@@ -146,11 +146,18 @@ export class PTUNpcQuickBuild extends FormApplication {
         // "remove pokemon" button
         $html.find('.pokemon-remove').on('click', function (event) {
             event.preventDefault();
-            // if (event.target.disabled) return;
-            // event.target.disabled = true;
             const dataset = this.closest(".party-pokemon")?.dataset;
-            globalThis.data.resetPokemonSlot(dataset?.slot);
-            globalThis.render(true);
+            globalThis.data.resetPokemonSlot(dataset?.slot).then(
+                ()=>globalThis.render(true));
+        });
+
+        // "randomize pokemon" button
+        $html.find('.pokemon-randomize').on('click', function (event) {
+            event.preventDefault();
+            const dataset = this.closest(".party-pokemon")?.dataset;
+            globalThis.loading().then(
+                ()=>globalThis.data.randomizePartyPokemon(dataset?.slot)).then(
+                ()=>globalThis.render(true));
         });
 
         // $html.find('.tab-button').on('click', (event) => {

--- a/src/module/apps/npc-quick-build/sheet.js
+++ b/src/module/apps/npc-quick-build/sheet.js
@@ -52,7 +52,7 @@ export class PTUNpcQuickBuild extends FormApplication {
             label: "Randomize",
             class: "randomize",
             icon: "fas fa-dice",
-            onclick: () => sheet.loading().then(()=>sheet.data.randomizeAll()).then(()=>sheet.renderAsync()).then(()=>this.unloading()).then(()=>this.disabled = false),
+            onclick: () => sheet.loading().then(()=>sheet.data.randomizeAll()).then(()=>sheet.renderAsync()).then(()=>this.disabled = false),
         })
 
         return buttons;
@@ -159,17 +159,17 @@ export class PTUNpcQuickBuild extends FormApplication {
         $html.find('.pokemon-remove').on('click', function (event) {
             event.preventDefault();
             const dataset = this.closest(".party-pokemon")?.dataset;
-            globalThis.data.resetPokemonSlot(dataset?.slot).then(
-                ()=>globalThis.render(true));
+            globalThis.data.resetPokemonSlot(dataset?.slot);
+            globalThis.render(true);
         });
 
         // "randomize pokemon" button
-        $html.find('.pokemon-randomize').on('click', function (event) {
+        $html.find('.pokemon-randomize').on('click', async function (event) {
             event.preventDefault();
             const dataset = this.closest(".party-pokemon")?.dataset;
-            globalThis.loading().then(
-                ()=>globalThis.data.randomizePartyPokemon(dataset?.slot)).then(
-                ()=>globalThis.render(true));
+            await globalThis.loading();
+            await globalThis.data.randomizePartyPokemon(dataset?.slot);
+            await globalThis.render(true);
         });
 
         // $html.find('.tab-button').on('click', (event) => {
@@ -284,6 +284,7 @@ export class PTUNpcQuickBuild extends FormApplication {
             });
             return this.unloading();
         });
+        await this.unloading();
         return this;
     }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2352,13 +2352,17 @@ a.content-link img {
   background-color: #19850d;
   color: white;
 }
-.ptu.pokemon.npc-quick-build .window-content .pokemon-box .pokemon-party-size {
+.ptu.pokemon.npc-quick-build .window-content .pokemon-box .pokemon-party-settings {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-bottom: 1em;
+}
+.ptu.pokemon.npc-quick-build .window-content .pokemon-box .pokemon-party-settings .pokemon-party-size {
   display: flex;
   align-items: baseline;
   gap: 1em;
-  margin-bottom: 1em;
 }
-.ptu.pokemon.npc-quick-build .window-content .pokemon-box .pokemon-party-size input {
+.ptu.pokemon.npc-quick-build .window-content .pokemon-box .pokemon-party-settings .pokemon-party-size input {
   flex: 0.25;
 }
 .ptu.pokemon.npc-quick-build .window-content .pokemon-box .all-party-pokemon {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2128,6 +2128,10 @@ a.content-link img {
   align-items: baseline;
   gap: 0.2em 2em;
 }
+.ptu.pokemon.npc-quick-build .window-content .selected-features .tagify,
+.ptu.pokemon.npc-quick-build .window-content .selected-edges .tagify {
+  min-width: 100%;
+}
 .ptu.pokemon.npc-quick-build .window-content .skills-box .skills,
 .ptu.pokemon.npc-quick-build .window-content .stats-box .stats {
   display: grid;
@@ -2479,6 +2483,8 @@ a.content-link img {
 .ptu.pokemon.npc-quick-build .window-content .pokemon-box .all-party-pokemon .party-pokemon .pokemon-remove {
   grid-column: 4;
   grid-row: 3;
+  justify-self: end;
+  padding-right: 5px;
 }
 .ptu.pokemon.npc-quick-build .window-content .pokemon-box .all-party-pokemon .party-pokemon .pokemon-randomize {
   grid-column: 4;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2389,7 +2389,7 @@ a.content-link img {
   padding: 0px 2px;
 }
 .ptu.pokemon.npc-quick-build .window-content .pokemon-box .all-party-pokemon .party-pokemon .pokemon-species {
-  grid-column: 1 / 5;
+  grid-column: 1 / 4;
   grid-row: 2;
 }
 .ptu.pokemon.npc-quick-build .window-content .pokemon-box .all-party-pokemon .party-pokemon .pokemon-img {
@@ -2470,6 +2470,10 @@ a.content-link img {
 .ptu.pokemon.npc-quick-build .window-content .pokemon-box .all-party-pokemon .party-pokemon .pokemon-remove {
   grid-column: 4;
   grid-row: 3;
+}
+.ptu.pokemon.npc-quick-build .window-content .pokemon-box .all-party-pokemon .party-pokemon .pokemon-randomize {
+  grid-column: 4;
+  grid-row: 2;
 }
 .ptu.pokemon.npc-quick-build .window-content .tagify.one-entry [role="textbox"]:not(:first-child) {
   display: none;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4719,6 +4719,10 @@ a.content-link img {
   color: black;
   flex: 1;
 }
+/* Tagify drop-down styling for NPC Quick Builder */
+.tagify__dropdown__item.crossclass {
+  background-color: lightcoral;
+}
 /* mod-field styling */
 .mod-input {
   position: relative;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2467,6 +2467,10 @@ a.content-link img {
 .ptu.pokemon.npc-quick-build .window-content .pokemon-box .all-party-pokemon .party-pokemon .pokemon-shiny.checked {
   opacity: 1;
 }
+.ptu.pokemon.npc-quick-build .window-content .pokemon-box .all-party-pokemon .party-pokemon .pokemon-remove {
+  grid-column: 4;
+  grid-row: 3;
+}
 .ptu.pokemon.npc-quick-build .window-content .tagify.one-entry [role="textbox"]:not(:first-child) {
   display: none;
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2348,6 +2348,15 @@ a.content-link img {
   background-color: #19850d;
   color: white;
 }
+.ptu.pokemon.npc-quick-build .window-content .pokemon-box .pokemon-party-size {
+  display: flex;
+  align-items: baseline;
+  gap: 1em;
+  margin-bottom: 1em;
+}
+.ptu.pokemon.npc-quick-build .window-content .pokemon-box .pokemon-party-size input {
+  flex: 0.25;
+}
 .ptu.pokemon.npc-quick-build .window-content .pokemon-box .all-party-pokemon {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/static/css/main.less
+++ b/static/css/main.less
@@ -2777,6 +2777,17 @@ a.content-link {
         }
 
         .pokemon-box {
+            .pokemon-party-size {
+                display: flex;
+                align-items: baseline;
+                gap: 1em;
+                margin-bottom: 1em;
+                
+                input {
+                    flex: 0.25;
+                }
+            }
+
             .all-party-pokemon {
                 display: grid;
                 grid-template-columns: 1fr 1fr;

--- a/static/css/main.less
+++ b/static/css/main.less
@@ -2609,6 +2609,13 @@ a.content-link {
             gap: 0.2em 2em;
         }
 
+        .selected-features,
+        .selected-edges {
+            .tagify {
+                min-width: 100%;
+            }
+        }
+
         .skills-box .skills,
         .stats-box .stats {
             display: grid;
@@ -2782,7 +2789,7 @@ a.content-link {
                 align-items: baseline;
                 gap: 1em;
                 margin-bottom: 1em;
-                
+
                 input {
                     flex: 0.25;
                 }
@@ -2929,6 +2936,8 @@ a.content-link {
                     .pokemon-remove {
                         grid-column: 4;
                         grid-row: 3;
+                        justify-self: end;
+                        padding-right: 5px;
                     }
 
                     .pokemon-randomize {

--- a/static/css/main.less
+++ b/static/css/main.less
@@ -2822,7 +2822,7 @@ a.content-link {
                     }
 
                     .pokemon-species {
-                        grid-column: 1 / 5;
+                        grid-column: 1 / 4;
                         grid-row: 2;
                     }
 
@@ -2918,6 +2918,11 @@ a.content-link {
                     .pokemon-remove {
                         grid-column: 4;
                         grid-row: 3;
+                    }
+
+                    .pokemon-randomize {
+                        grid-column: 4;
+                        grid-row: 2;
                     }
                 }
             }

--- a/static/css/main.less
+++ b/static/css/main.less
@@ -2784,15 +2784,21 @@ a.content-link {
         }
 
         .pokemon-box {
-            .pokemon-party-size {
-                display: flex;
-                align-items: baseline;
-                gap: 1em;
+            .pokemon-party-settings {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
                 margin-bottom: 1em;
 
-                input {
-                    flex: 0.25;
+                .pokemon-party-size {
+                    display: flex;
+                    align-items: baseline;
+                    gap: 1em;
+    
+                    input {
+                        flex: 0.25;
+                    }
                 }
+
             }
 
             .all-party-pokemon {

--- a/static/css/main.less
+++ b/static/css/main.less
@@ -2776,7 +2776,6 @@ a.content-link {
             }
         }
 
-
         .pokemon-box {
             .all-party-pokemon {
                 display: grid;
@@ -2914,6 +2913,11 @@ a.content-link {
                         &.checked {
                             opacity: 1;
                         }
+                    }
+
+                    .pokemon-remove {
+                        grid-column: 4;
+                        grid-row: 3;
                     }
                 }
             }

--- a/static/css/main.less
+++ b/static/css/main.less
@@ -5668,6 +5668,13 @@ a.content-link {
     }
 }
 
+/* Tagify drop-down styling for NPC Quick Builder */
+.tagify__dropdown__item {
+    &.crossclass {
+        background-color: lightcoral;
+    }
+}
+
 
 /* mod-field styling */
 .mod-input {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -531,6 +531,7 @@
       "Skills": "Skills",
       "Stats": "Stats",
       "PartyPkmn": "Party Pokemon",
+      "PartySize": "Party Size",
       "Level": "Level",
       "Lv": "Lv.",
       "Gender": "Gender",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -537,6 +537,7 @@
       "Sex": "Sex",
       "Shiny": "Shiny",
       "SpeciesName": "Species",
+      "RemovePokemon": "Remove Pokemon",
       "Page": {
         "TrainerInfo": "Trainer Info",
         "FeaturesEdges": "Features & Edges",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -538,6 +538,7 @@
       "Shiny": "Shiny",
       "SpeciesName": "Species",
       "RemovePokemon": "Remove Pokemon",
+      "RandomizePokemon": "Randomize Pokemon",
       "Page": {
         "TrainerInfo": "Trainer Info",
         "FeaturesEdges": "Features & Edges",

--- a/static/templates/apps/npc-quick-build-sheet.hbs
+++ b/static/templates/apps/npc-quick-build-sheet.hbs
@@ -208,7 +208,7 @@
                             <input class="ptu-tagify one-entry" name="party.{{key}}.species.selected" data-filter-name="species" value="{{json pkmn.species.selected}}" data-dtype="JSON" />
                         </div>
 
-                        <a class="pokemon-randomize" data-tooltip="PTU.NpcQuickBuild.Randomize"><i class="fa-solid fa-dice"></i></a>
+                        <a class="pokemon-randomize" data-tooltip="PTU.NpcQuickBuild.RandomizePokemon"><i class="fa-solid fa-dice"></i></a>
                     </div>
                 {{/if}}
                 {{/each}}

--- a/static/templates/apps/npc-quick-build-sheet.hbs
+++ b/static/templates/apps/npc-quick-build-sheet.hbs
@@ -200,6 +200,8 @@
                             <label>{{localize "PTU.NpcQuickBuild.SpeciesName"}}</label>
                             <input class="ptu-tagify one-entry" name="party.{{key}}.species.selected" data-filter-name="species" value="{{json pkmn.species.selected}}" data-dtype="JSON" />
                         </div>
+
+                        <a class="pokemon-randomize" data-tooltip="PTU.NpcQuickBuild.Randomize"><i class="fa-solid fa-dice"></i></a>
                     </div>
                 {{/if}}
                 {{/each}}

--- a/static/templates/apps/npc-quick-build-sheet.hbs
+++ b/static/templates/apps/npc-quick-build-sheet.hbs
@@ -63,7 +63,7 @@
 
             <div class="selected-edges">
                 <h4>{{localize "PTU.NpcQuickBuild.Edges"}}</h4>
-                <input class="ptu-tagify trainer-features" name="trainer.edges.selected" data-filter-name="edges" value="{{json data.trainer.edges.selected}}" data-dtype="JSON" />
+                <input class="ptu-tagify trainer-edges" name="trainer.edges.selected" data-filter-name="edges" value="{{json data.trainer.edges.selected}}" data-dtype="JSON" />
             </div>
 
             <div class="computed-links computed-edges">

--- a/static/templates/apps/npc-quick-build-sheet.hbs
+++ b/static/templates/apps/npc-quick-build-sheet.hbs
@@ -154,9 +154,21 @@
         {{#if (eq data.page 4)}}
             <div class="pokemon-box">
                 <h4>{{localize "PTU.NpcQuickBuild.PartyPkmn"}}</h4>
-                <div class="pokemon-party-size">
-                    <label>{{localize "PTU.NpcQuickBuild.PartySize"}}</label>
-                    <input type="number" name="trainer.partySize" min="1" value="{{data.trainer.partySize}}"/>
+                <div class="pokemon-party-settings">
+                    <div class="pokemon-party-size">
+                        <label>{{localize "PTU.NpcQuickBuild.PartySize"}}</label>
+                        <input type="number" name="trainer.partySize" min="1" value="{{data.trainer.partySize}}"/>
+                    </div>
+                    <div class="pokemon-data-source">
+                        <select id="sourceSelect">
+                            {{selectOptions data.sourceSelect.options selected=data.sourceSelect.value valueAttr="uuid"}}
+                        </select>
+                        {{#if data.sourceSelect.link.uuid}}
+                        <div>
+                            {{localize "PTU.MassGenerator.FoundTable"}} <a class="content-link" draggable="true" data-link="" data-uuid="{{data.sourceSelect.link.uuid}}" data-id="{{data.sourceSelect.link._id}}" data-type="RollTable" data-tooltip="Roll Table"><i class="fas fa-th-list"></i>{{data.sourceSelect.link.label}}</a>
+                        </div>
+                        {{/if}}
+                    </div>
                 </div>
                 <div class="all-party-pokemon">
                 {{#each data.party as | pkmn key |}}

--- a/static/templates/apps/npc-quick-build-sheet.hbs
+++ b/static/templates/apps/npc-quick-build-sheet.hbs
@@ -191,6 +191,8 @@
                                 <input type="checkbox" name="party.{{key}}.shiny" {{checked pkmn.shiny}}/>
                             </label>
                         </div>
+
+                        <a class="pokemon-remove" data-tooltip="PTU.NpcQuickBuild.RemovePokemon"><i class="fa-solid fa-trash"></i></a>
                     </div>
                 {{else}}
                     <div class="party-pokemon {{key}} species-unset" data-slot="{{key}}">

--- a/static/templates/apps/npc-quick-build-sheet.hbs
+++ b/static/templates/apps/npc-quick-build-sheet.hbs
@@ -43,6 +43,9 @@
             <label>{{localize "PTU.NpcQuickBuild.TrainerLevel"}}</label>
             <input class="fb-40" type="number" name="trainer.level" min="1" max="50" value="{{data.trainer.level}}"/>
 
+            <label>{{localize "PTU.NpcQuickBuild.PartySize"}}</label>
+            <input class="fb-40" type="number" name="trainer.partySize" min="1" value="{{data.trainer.partySize}}"/>
+
             <label>{{localize "PTU.NpcQuickBuild.Classes"}}</label>
             <input class="ptu-tagify trainer-classes" name="trainer.classes.selected" data-filter-name="classes" value="{{json data.trainer.classes.selected}}" data-dtype="JSON" />
         </div>
@@ -151,6 +154,10 @@
         {{#if (eq data.page 4)}}
             <div class="pokemon-box">
                 <h4>{{localize "PTU.NpcQuickBuild.PartyPkmn"}}</h4>
+                <div class="pokemon-party-size">
+                    <label>{{localize "PTU.NpcQuickBuild.PartySize"}}</label>
+                    <input type="number" name="trainer.partySize" min="1" value="{{data.trainer.partySize}}"/>
+                </div>
                 <div class="all-party-pokemon">
                 {{#each data.party as | pkmn key |}}
                 {{#if pkmn.configured}}


### PR DESCRIPTION
Implements some suggestions from #805

1. Ability to remove and reroll generated pokemon
2. If classes have already been selected, exclude feats from other classes in the drop down.
3. Being able to chose two of the same feats/edges (Example: `Elemental Connection`)
4. Select the random source for the Party Pokemon generation (compendium or rolltables). This should help eliminate the need for the complex query logic to support:
    - Being able to exclude certain pokemon like the fakemon or legendaries from the randomizer
    - On the pokemon tab maybe have an option to only choose pokemon of a certain type with the randomizer
7. Select the party size of the trainer, permitting more than 6 pokemon.