### PR TITLE
Correctly Update Pokemon Sprite and Name On Evolution

### DIFF
--- a/src/module/actor/pokemon/document.js
+++ b/src/module/actor/pokemon/document.js
@@ -579,7 +579,9 @@ class PTUPokemonActor extends PTUActor {
                 tokenUpdates["height"] = update["prototypeToken.height"];
             }
 
-            if (Object.keys(update).length > 0) await this.update(update);
+            if (Object.keys(update).length > 0) {
+                foundry.utils.mergeObject(changed, foundry.utils.expandObject(update));
+            }
             if (Object.keys(tokenUpdates).length > 0) {
                 for (const token of this.getActiveTokens()) {
                     await token.document.update(tokenUpdates);


### PR DESCRIPTION
Fixes #811

In the pre-update hook on level-up/evolution, we're doing an `update` call to update the name and image, but those updates are overwritten when the pre-update hook completes. This work removes the direct update *inside* the pre-update hook, instead updating the `changed` fields to their new values to prevent them being overwritten by the original update