### PR TITLE
Use updateSource inside a pokemon's preUpdate function

### DIFF
--- a/src/module/actor/pokemon/document.js
+++ b/src/module/actor/pokemon/document.js
@@ -579,7 +579,7 @@ class PTUPokemonActor extends PTUActor {
                 tokenUpdates["height"] = update["prototypeToken.height"];
             }
 
-            if (Object.keys(update).length > 0) await this.update(update);
+            if (Object.keys(update).length > 0) await this.updateSource(update);
             if (Object.keys(tokenUpdates).length > 0) {
                 for (const token of this.getActiveTokens()) {
                     await token.document.update(tokenUpdates);


### PR DESCRIPTION
Fixes #817

Don't trigger a second Actor.update in the middle of an Actor._preUpdate event

If we did, the changes from the second update would be overwritten by anything in the first update (which in the case of updating the sheet, is every single field on the actor)